### PR TITLE
CI: Add support for RHEL-9

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -50,6 +50,7 @@ galaxy_info:
     - name: EL
       versions:
         - 8
+        - 9
 
   # List tags for your role here, one per line. A tag is a keyword that
   # describes and categorizes the role. Users find roles by searching for tags.

--- a/vars/RedHat_9.yml
+++ b/vars/RedHat_9.yml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: MIT
+---
+# Put internal variables here with Red Hat Enterprise Linux 9 specific values.
+
+__ha_cluster_repos:
+  - "rhel-9-for-{{ ansible_architecture }}-highavailability-rpms"


### PR DESCRIPTION
The rhel-8-y status is the latest unreleased RHEL-8 and the rhel-x status is pre-released RHEL-9.