### PR TITLE
Fix issues related to enabling repositories

### DIFF
--- a/tasks/enable-repositories/CentOS.yml
+++ b/tasks/enable-repositories/CentOS.yml
@@ -1,14 +1,28 @@
 # SPDX-License-Identifier: MIT
 ---
+- name: List active CentOS repositories
+  command:
+    cmd: dnf repolist
+    # See the comment bellow.
+    warn: no
+  register: __ha_cluster_repolist
+  changed_when: no
+  check_mode: no
+
 - name: Enable CentOS repositories
   command:
-    cmd: "dnf config-manager --set-enabled {{ item | quote }}"
-    # There doesn't seem to be a plugin for enabling already defined repos. So
-    # we silence the warning which recommends using an ansible plugin instead
-    # of running dnf command.
+    cmd: "dnf config-manager --set-enabled {{ item.id | quote }}"
+    # Silence a warning which recommends using ansible dnf module instead of
+    # running dnf command.
+    #
+    # yum_repository module documentation states, "If you wish to update an
+    # existing repository definition use ini_file instead."
+    #
+    # ini_file requires a file path and a section name, both of which are
+    # different in various CentOS minor versions.
+    #
+    # Using dnf, similar differences must also be handled. But at least the
+    # approach and __ha_cluster_repos structure is the same as for RHEL.
     warn: no
   loop: "{{ __ha_cluster_repos }}"
-  # The dnf command does not indicate if any changes have been made. To silence
-  # ansible lint (301 Commands should not change things if nothing needs doing),
-  # changed_when is set explicitly.
-  changed_when: yes
+  when: item.name not in __ha_cluster_repolist.stdout

--- a/tasks/enable-repositories/CentOS.yml
+++ b/tasks/enable-repositories/CentOS.yml
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Enable CentOS repositories
+  command:
+    cmd: "dnf config-manager --set-enabled {{ item | quote }}"
+    # There doesn't seem to be a plugin for enabling already defined repos. So
+    # we silence the warning which recommends using an ansible plugin instead
+    # of running dnf command.
+    warn: no
+  loop: "{{ __ha_cluster_repos }}"
+  # The dnf command does not indicate if any changes have been made. To silence
+  # ansible lint (301 Commands should not change things if nothing needs doing),
+  # changed_when is set explicitly.
+  changed_when: yes

--- a/tasks/enable-repositories/Fedora.yml
+++ b/tasks/enable-repositories/Fedora.yml
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: MIT
+---
+# No enable-repositories tasks are needed for Fedora. This file serves as a
+# placeholder and prevents RedHat.yml to be executed instead.

--- a/tasks/enable-repositories/RedHat.yml
+++ b/tasks/enable-repositories/RedHat.yml
@@ -1,7 +1,16 @@
 # SPDX-License-Identifier: MIT
 ---
+- name: List active RHEL repositories
+  command:
+    cmd: dnf repolist
+    warn: no
+  register: __ha_cluster_repolist
+  changed_when: no
+  check_mode: no
+
 - name: Enable RHEL repositories
   rhsm_repository:
-    name: "{{ item }}"
+    name: "{{ item.id }}"
     state: enabled
   loop: "{{ __ha_cluster_repos }}"
+  when: item.name not in __ha_cluster_repolist.stdout

--- a/tasks/enable-repositories/RedHat.yml
+++ b/tasks/enable-repositories/RedHat.yml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Enable RHEL repositories
+  rhsm_repository:
+    name: "{{ item }}"
+    state: enabled
+  loop: "{{ __ha_cluster_repos }}"

--- a/tasks/install-and-configure-packages.yml
+++ b/tasks/install-and-configure-packages.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 ---
-- name: Find platform/version specific tasks for enable repositories
+- name: Find platform/version specific tasks to enable repositories
   set_fact:
     __ha_cluster_enable_repo_tasks_file: "{{ \
       __ha_cluster_enable_repo_tasks_file_candidate \
@@ -21,7 +21,7 @@
     - ha_cluster_enable_repos
     - __ha_cluster_enable_repo_tasks_file_candidate is file
 
-- name: Run platform/version specific tasks for enable repositories
+- name: Run platform/version specific tasks to enable repositories
   include_tasks: "{{ __ha_cluster_enable_repo_tasks_file }}"
   when:
     - ha_cluster_enable_repos

--- a/tasks/install-and-configure-packages.yml
+++ b/tasks/install-and-configure-packages.yml
@@ -1,21 +1,31 @@
-- name: Enable RHEL repositories
-  rhsm_repository:
-    name: "{{ item }}"
-    state: enabled
-  loop: "{{ __ha_cluster_repos }}"
+# SPDX-License-Identifier: MIT
+---
+- name: Find platform/version specific tasks for enable repositories
+  set_fact:
+    __ha_cluster_enable_repo_tasks_file: "{{ \
+      __ha_cluster_enable_repo_tasks_file_candidate \
+    }}"
+  loop:
+    - "{{ ansible_facts['os_family'] }}.yml"
+    - "{{ ansible_facts['distribution'] }}.yml"
+    - >-
+      {{ ansible_facts['distribution'] ~ '_' ~
+      ansible_facts['distribution_major_version'] }}.yml
+    - >-
+      {{ ansible_facts['distribution'] ~ '_' ~
+      ansible_facts['distribution_version'] }}.yml
+  vars:
+    __ha_cluster_enable_repo_tasks_file_candidate: "{{ \
+      role_path }}/tasks/enable-repositories/{{ item }}"
   when:
-    - ansible_distribution == "RedHat"
     - ha_cluster_enable_repos
+    - __ha_cluster_enable_repo_tasks_file_candidate is file
 
-- name: Enable CentOS repositories
-  command:
-    cmd: "dnf config-manager --set-enabled {{ item | quote }}"
-    # there doesn't seem to be a plugin for enabling already defined repos
-    warn: no
-  loop: "{{ __ha_cluster_repos }}"
+- name: Run platform/version specific tasks for enable repositories
+  include_tasks: "{{ __ha_cluster_enable_repo_tasks_file }}"
   when:
-    - ansible_distribution == "CentOS"
     - ha_cluster_enable_repos
+    - __ha_cluster_enable_repo_tasks_file is defined
 
 - name: Install cluster packages
   package:

--- a/vars/CentOS_8.0.yml
+++ b/vars/CentOS_8.0.yml
@@ -2,5 +2,9 @@
 ---
 # Put internal variables here with CentOS 8 specific values.
 
+# List of repositories holding HA cluster packages.
+# id: repo ID used to enable the repo
+# name: user-friendly name of a repo used to check if the repo is enabled
 __ha_cluster_repos:
-  - HighAvailability
+  - id: HighAvailability
+    name: HighAvailability

--- a/vars/CentOS_8.0.yml
+++ b/vars/CentOS_8.0.yml
@@ -3,4 +3,4 @@
 # Put internal variables here with CentOS 8 specific values.
 
 __ha_cluster_repos:
-  - ha
+  - HighAvailability

--- a/vars/CentOS_8.1.yml
+++ b/vars/CentOS_8.1.yml
@@ -1,0 +1,1 @@
+CentOS_8.0.yml

--- a/vars/CentOS_8.2.yml
+++ b/vars/CentOS_8.2.yml
@@ -1,0 +1,1 @@
+CentOS_8.0.yml

--- a/vars/CentOS_8.yml
+++ b/vars/CentOS_8.yml
@@ -2,5 +2,9 @@
 ---
 # Put internal variables here with CentOS 8 specific values.
 
+# List of repositories holding HA cluster packages.
+# id: repo ID used to enable the repo
+# name: user-friendly name of a repo used to check if the repo is enabled
 __ha_cluster_repos:
-  - ha
+  - id: ha
+    name: HighAvailability

--- a/vars/RedHat_8.yml
+++ b/vars/RedHat_8.yml
@@ -2,5 +2,9 @@
 ---
 # Put internal variables here with Red Hat Enterprise Linux 8 specific values.
 
+# List of repositories holding HA cluster packages.
+# id: repo ID used to enable the repo
+# name: user-friendly name of a repo used to check if the repo is enabled
 __ha_cluster_repos:
-  - "rhel-8-for-{{ ansible_architecture }}-highavailability-rpms"
+  - id: "rhel-8-for-{{ ansible_architecture }}-highavailability-rpms"
+    name: "High Availability"

--- a/vars/RedHat_9.yml
+++ b/vars/RedHat_9.yml
@@ -2,5 +2,9 @@
 ---
 # Put internal variables here with Red Hat Enterprise Linux 9 specific values.
 
+# List of repositories holding HA cluster packages.
+# id: repo ID used to enable the repo
+# name: user-friendly name of a repo used to check if the repo is enabled
 __ha_cluster_repos:
-  - "rhel-9-for-{{ ansible_architecture }}-highavailability-rpms"
+  - id: "rhel-9-for-{{ ansible_architecture }}-highavailability-rpms"
+    name: "High Availability"


### PR DESCRIPTION
This pull request fixes two issues:
* In CentOS 8.3, the `HighAvailability` repository got renamed to `ha`. I updated the role to reflect that.
* Tasks for enabling repositories have been extracted to separate files. This way, tasks for new platform/version can be added in the same way as variable files.