### PR TITLE
do not fail if openssl is not installed

### DIFF
--- a/tasks/presharedkey.yml
+++ b/tasks/presharedkey.yml
@@ -35,9 +35,17 @@
   delegate_to: localhost
 
 - name: Generate random {{ preshared_key_label }}
-  set_fact:
-    __ha_cluster_some_preshared_key: >
-      "{{ lookup('pipe', 'openssl rand -base64 {{ preshared_key_length }}') }}"
+  block:
+    - name: Generate {{ preshared_key_label }} using OpenSSL
+      command:
+        cmd: openssl rand -base64 {{ preshared_key_length | quote }}
+      register: __ha_cluster_openssl_rand
+      changed_when: no
+
+    - name: Fetch generated {{ preshared_key_label }}
+      set_fact:
+        __ha_cluster_some_preshared_key: >
+          "{{ __ha_cluster_openssl_rand.stdout }}"
   when:
     - not (preshared_key_src is string and preshared_key_src | length > 1)
   run_once: yes

--- a/tests/tasks/fixture_psks.yml
+++ b/tests/tasks/fixture_psks.yml
@@ -1,7 +1,12 @@
 # SPDX-License-Identifier: MIT
 ---
-- name: Generate pre-shared keys and certificates on controller
+- name: Generate pre-shared keys and certificates on the controller
   block:
+    - name: Ensure OpenSSL is installed on the controller
+      package:
+        name: openssl
+        state: present
+
     - name: Ensure a directory for temporary files exists
       file:
         path: "{{ playbook_dir }}/tmp"
@@ -26,27 +31,21 @@
         privatekey_path: "{{ __test_pcsd_private_key_path }}"
         provider: selfsigned
 
-    - name: Generate pre-shared keys
-      set_fact:
-        __test_corosync_key: "{{ lookup('pipe', 'openssl rand -base64 256') }}"
-        __test_pacemaker_key: "{{ lookup('pipe', 'openssl rand -base64 256') }}"
-        __test_fence_xvm_key: "{{ lookup('pipe', 'openssl rand -base64 512') }}"
-
-    - name: Save corosync key
+    - name: Generate corosync key
       copy:
-        content: "{{ __test_corosync_key | b64decode }}"
+        content: "{{ lookup('pipe', 'openssl rand -base64 256') | b64decode }}"
         dest: "{{ __test_corosync_key_path }}"
         mode: 0400
 
-    - name: Save pacemaker key
+    - name: Generate pacemaker key
       copy:
-        content: "{{ __test_pacemaker_key | b64decode }}"
+        content: "{{ lookup('pipe', 'openssl rand -base64 256') | b64decode }}"
         dest: "{{ __test_pacemaker_key_path }}"
         mode: 0400
 
-    - name: Save fence_xvm key
+    - name: Generate fence_xvm key
       copy:
-        content: "{{ __test_fence_xvm_key | b64decode }}"
+        content: "{{ lookup('pipe', 'openssl rand -base64 512') | b64decode }}"
         dest: "{{ __test_fence_xvm_key_path }}"
         mode: 0400
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -17,6 +17,7 @@ __ha_cluster_fullstack_node_packages:
   - libknet1-plugins-all
   - pacemaker
   - pcs
+  - openssl  # used in the role for generating preshared keys
 
 __ha_cluster_services:
   - corosync


### PR DESCRIPTION
OpenSSL is used in the role and automated tests to generate random
preshared keys. Previously, OpenSSL was a dependency of pcs. That is no
longer the case since pcs-0.10.8-2.

In the role, keys are no longer generated on the controller, so the role
does not install OpenSSL there. Instead, preshared keys are now
generated on target nodes and the role newly ensures OpenSSL is installed on
target nodes.

In tests, OpenSSL is needed on the controller to test cases when
preshared keys are distributed from the controller. Tests ensure OpenSSL
is installed on the controller.