### PR TITLE
fix password_hash salt length

### DIFF
--- a/tasks/install-and-configure-packages.yml
+++ b/tasks/install-and-configure-packages.yml
@@ -45,5 +45,8 @@
     name: hacluster
     password: "{{
       ha_cluster_hacluster_password
-      | password_hash('sha512', ansible_hostname|replace('-','x'))
+      | password_hash(
+          'sha512',
+          ansible_hostname|replace('-','x')|truncate(16, True, '')
+        )
     }}"


### PR DESCRIPTION
Ansible 2.11 has strict checking for password_hash salt length.
If the given salt length is not equal to, or greater than, the
salt length for the hash algorithm (depending on the algorithm, the
salt length must be equal, or less than), Ansible will emit an
error like "invalid salt size".  To fix this, use the `truncate`
filter to ensure the salt length is not too long.