### PR TITLE
replace rhsm_repository with subscription-manager cli

### DIFF
--- a/tasks/enable-repositories/RedHat.yml
+++ b/tasks/enable-repositories/RedHat.yml
@@ -9,8 +9,6 @@
   check_mode: no
 
 - name: Enable RHEL repositories
-  rhsm_repository:
-    name: "{{ item.id }}"
-    state: enabled
+  command: subscription-manager repos --enable {{ item.id | quote }}
   loop: "{{ __ha_cluster_repos }}"
   when: item.name not in __ha_cluster_repolist.stdout


### PR DESCRIPTION
The `rhsm_repository` module is not supported by ansible-core, so
use the subscription-manager cli instead.