### PR TITLE
add SBD support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ An Ansible role for managing High Availability Clustering.
   settings not specified in the role variables will be lost.
 * For now, the role is capable of configuring:
   * a basic corosync cluster
+  * SBD
   * pacemaker cluster properties
   * stonith and resources
   * resource constraints
@@ -177,37 +178,28 @@ string, default: `my-cluster`
 
 Name of the cluster.
 
-#### `ha_cluster_sbd_enable`
+#### `ha_cluster_sbd_enabled`
 
-bool, default: `false`
+boolean, default: `no`
 
 Defines whether to use SBD.
 
-#### `ha_cluster_sbd_devices`
+You may take a look at [an example](#configuring-cluster-to-use-sbd).
+
+#### `ha_cluster_sbd_options`
 
 list, default: `[]`
 
-List of devices (string) to use.
+List of name-value dictionaries specifying SBD options. Supported options are:
+`delay-start` (defaults to `no`), `startmode` (defaults to `always`),
+`timeout-action` (defaults to `flush,reboot`) and `watchdog-timeout` (defaults
+to `5`). See `sbd(8)` man page, section 'Configuration via environment' for
+their description.
 
-#### `ha_cluster_sbd_create_params`
+You may take a look at [an example](#configuring-cluster-to-use-sbd).
 
-str, default: `''`
-
-SBD parameters specified when creating the disks
-
-#### `ha_cluster_sbd_daemon_params`
-
-str, default: '`-W`'
-
-SBD daemon parameters used for startup
-
-#### `ha_cluster_sbd_startmode`
-
-str, default: '`always`'
-
-SBD cluster start mode. The default value will ensure that cluster nodes can re-join after being fenced. The more secure value is '`clean`'.
-
-#### `ha_cluster_`
+Watchdog and SBD devices are configured on a node to node basis in
+[inventory](#sbd-watchdog-and-devices).
 
 #### `ha_cluster_cluster_properties`
 
@@ -666,6 +658,7 @@ You may take a look at
 
 ### Inventory
 
+#### Nodes' names and addresses
 Nodes' names and addresses can be configured in inventory. This is optional. If
 no names or addresses are configured, play's targets will be used.
 
@@ -695,6 +688,35 @@ all:
 * `corosync_addresses` - list of addresses used by Corosync, all nodes must
   have the same number of addresses and the order of the addresses matters
 
+#### SBD watchdog and devices
+When using SBD, you may optionally configure watchdog and SBD devices for each
+node in inventory. Even though all SBD devices must be shared to and accesible
+from all nodes, each node may use different names for the devices. Watchdog may
+be different for each node as well. See also [SBD
+variables](#ha_cluster_sbd_enabled).
+
+Example inventory with targets `node1` and `node2`:
+```yaml
+all:
+  hosts:
+    node1:
+      ha_cluster:
+        sbd_watchdog: /dev/watchdog2
+        sbd_devices:
+          - /dev/vdx
+          - /dev/vdy
+    node2:
+      ha_cluster:
+        sbd_watchdog: /dev/watchdog1
+        sbd_devices:
+          - /dev/vdw
+          - /dev/vdz
+```
+
+* `sbd_watchdog` (optional) - Watchdog device to be used by SBD. Defaults to
+  `/dev/watchdog` if not set.
+* `sbd_devices` (optional) - Devices to use for exchanging SBD messages and for
+  monitoring. Defaults to empty list if not set.
 
 ## Example Playbooks
 
@@ -704,6 +726,27 @@ all:
   vars:
     ha_cluster_cluster_name: my-new-cluster
     ha_cluster_hacluster_password: password
+
+  roles:
+    - linux-system-roles.ha_cluster
+```
+
+### Configuring cluster to use SBD
+```yaml
+- hosts: node1 node2
+  vars:
+    ha_cluster_cluster_name: my-new-cluster
+    ha_cluster_hacluster_password: password
+    ha_cluster_sbd_enabled: yes
+    ha_cluster_sbd_options:
+      - name: delay-start
+        value: 'no'
+      - name: startmode
+        value: always
+      - name: timeout-action
+        value: 'flush,reboot'
+      - name: watchdog-timeout
+        value: 5
 
   roles:
     - linux-system-roles.ha_cluster

--- a/README.md
+++ b/README.md
@@ -177,6 +177,38 @@ string, default: `my-cluster`
 
 Name of the cluster.
 
+#### `ha_cluster_sbd_enable`
+
+bool, default: `false`
+
+Defines whether to use SBD.
+
+#### `ha_cluster_sbd_devices`
+
+list, default: `[]`
+
+List of devices (string) to use.
+
+#### `ha_cluster_sbd_create_params`
+
+str, default: `''`
+
+SBD parameters specified when creating the disks
+
+#### `ha_cluster_sbd_daemon_params`
+
+str, default: '`-W`'
+
+SBD daemon parameters used for startup
+
+#### `ha_cluster_sbd_startmode`
+
+str, default: '`always`'
+
+SBD cluster start mode. The default value will ensure that cluster nodes can re-join after being fenced. The more secure value is '`clean`'.
+
+#### `ha_cluster_`
+
 #### `ha_cluster_cluster_properties`
 
 structure, default: no properties

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,11 +22,8 @@ ha_cluster_pcsd_private_key_src: null
 
 ha_cluster_cluster_name: my-cluster
 
-ha_cluster_sbd_enable: false
-ha_cluster_sbd_devices: []
-ha_cluster_sbd_create_params: ""
-ha_cluster_sbd_daemon_params: "-W"
-ha_cluster_sbd_startmode: "always"
+ha_cluster_sbd_enabled: no
+ha_cluster_sbd_options: []
 
 ha_cluster_pcs_permission_list:
   - type: group
@@ -37,6 +34,7 @@ ha_cluster_pcs_permission_list:
       - write
 
 ha_cluster_cluster_properties: []
+
 ha_cluster_resource_primitives: []
 ha_cluster_resource_groups: []
 ha_cluster_resource_clones: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,6 +22,12 @@ ha_cluster_pcsd_private_key_src: null
 
 ha_cluster_cluster_name: my-cluster
 
+ha_cluster_sbd_enable: false
+ha_cluster_sbd_devices: []
+ha_cluster_sbd_create_params: ""
+ha_cluster_sbd_daemon_params: "-W"
+ha_cluster_sbd_startmode: "always"
+
 ha_cluster_pcs_permission_list:
   - type: group
     name: haclient

--- a/examples/sbd.yml
+++ b/examples/sbd.yml
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: MIT
+---
+- hosts: node1 node2
+  vars:
+    ha_cluster_cluster_name: my-new-cluster
+    ha_cluster_hacluster_password: password
+    ha_cluster_sbd_enabled: yes
+    ha_cluster_sbd_options:
+      - name: delay-start
+        value: 'no'
+      - name: startmode
+        value: always
+      - name: timeout-action
+        value: 'flush,reboot'
+      - name: watchdog-timeout
+        value: 5
+
+  roles:
+    - linux-system-roles.ha_cluster

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,3 @@
 # SPDX-License-Identifier: MIT
 ---
-- name: Load softdog module
-  command: modprobe softdog
+# Put handlers for tasks here.

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,4 @@
 # SPDX-License-Identifier: MIT
 ---
-# Put handlers for tasks here.
+- name: Load softdog module
+  shell: modprobe softdog

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: MIT
 ---
 - name: Load softdog module
-  shell: modprobe softdog
+  command: modprobe softdog

--- a/tasks/check-and-prepare-role-variables.yml
+++ b/tasks/check-and-prepare-role-variables.yml
@@ -13,11 +13,13 @@
     - name: Fail if nodes do not have the same number of SBD devices specified
       fail:
         msg: All nodes must have the same number of SBD devices specified
-      when: >
-        ansible_play_hosts_all
-        | map('extract', hostvars, ['ha_cluster', 'sbd_devices'])
-        | map('default', [], true)
-        | map('length') | unique | length > 1
+      when:
+        - ha_cluster_sbd_enabled
+        - >
+          ansible_play_hosts_all
+          | map('extract', hostvars, ['ha_cluster', 'sbd_devices'])
+          | map('default', [], true)
+          | map('length') | unique | length > 1
       run_once: yes
   when: ha_cluster_cluster_present
 

--- a/tasks/check-and-prepare-role-variables.yml
+++ b/tasks/check-and-prepare-role-variables.yml
@@ -9,6 +9,16 @@
       loop:
         - ha_cluster_hacluster_password
       run_once: yes
+
+    - name: Fail if nodes do not have the same number of SBD devices specified
+      fail:
+        msg: All nodes must have the same number of SBD devices specified
+      when: >
+        ansible_play_hosts_all
+        | map('extract', hostvars, ['ha_cluster', 'sbd_devices'])
+        | map('default', [], true)
+        | map('length') | unique | length > 1
+      run_once: yes
   when: ha_cluster_cluster_present
 
 - name: Discover cluster node names

--- a/tasks/cluster-enable-disable.yml
+++ b/tasks/cluster-enable-disable.yml
@@ -12,14 +12,3 @@
     # nodes are configured to start the cluster on boot while other nodes in
     # the same cluster are not.
     - item != 'corosync-qdevice' or __ha_cluster_qdevice_in_use
-
-- name: Get services status - detect SBD
-  service_facts:
-
-# The role does not support configuring SBD yet, therefore we always disable it.
-- name: Disable SBD
-  service:
-    name: sbd
-    enabled: no
-  when:
-    - '"sbd.service" in ansible_facts.services'

--- a/tasks/cluster-enable-disable.yml
+++ b/tasks/cluster-enable-disable.yml
@@ -12,3 +12,19 @@
     # nodes are configured to start the cluster on boot while other nodes in
     # the same cluster are not.
     - item != 'corosync-qdevice' or __ha_cluster_qdevice_in_use
+
+- name: Get services status - detect SBD
+  service_facts:
+
+- name: Enable or disable SBD
+  service:
+    name: sbd
+    enabled: "{{ ha_cluster_sbd_enabled }}"
+    # Null (i.e. nochange) is currently not supported: Either all nodes are
+    # configured to start the cluster on boot or not to start the cluster on
+    # boot. Null (nochange) could lead to situations where part of cluster
+    # nodes are configured to start the cluster on boot while other nodes in
+    # the same cluster are not.
+  when:
+    - '"sbd.service" in ansible_facts.services'
+  register: __ha_cluster_sbd_service_enable_disable

--- a/tasks/cluster-enable-disable.yml
+++ b/tasks/cluster-enable-disable.yml
@@ -19,7 +19,7 @@
 - name: Enable or disable SBD
   service:
     name: sbd
-    enabled: "{{ ha_cluster_sbd_enabled }}"
+    enabled: "{{ ha_cluster_sbd_enabled and ha_cluster_start_on_boot }}"
     # Null (i.e. nochange) is currently not supported: Either all nodes are
     # configured to start the cluster on boot or not to start the cluster on
     # boot. Null (nochange) could lead to situations where part of cluster

--- a/tasks/cluster-setup-pcs-0.10.yml
+++ b/tasks/cluster-setup-pcs-0.10.yml
@@ -16,6 +16,9 @@
           addr={{ addr | quote }}
         {% endfor %}
       {% endfor %}
+      {% if __ha_cluster_sbd_needs_atb | default(false) %}
+        quorum auto_tie_breaker=1
+      {% endif %}
   run_once: yes
   # We always need to create corosync.conf file to see whether it's the same as
   # what is already present on the cluster nodes. However, we don't want to

--- a/tasks/cluster-start-and-reload.yml
+++ b/tasks/cluster-start-and-reload.yml
@@ -34,6 +34,8 @@
         __ha_cluster_distribute_corosync_conf.changed
         or __ha_cluster_distribute_corosync_authkey.changed
         or __ha_cluster_distribute_pacemaker_authkey.changed
+        or (__ha_cluster_sbd_service_enable_disable.changed | default(false))
+        or (__ha_cluster_distribute_sbd_config.changed | default(false))
     - >
         item != 'corosync-qdevice'
         or 'corosync-qdevice.service' in ansible_facts.services

--- a/tasks/create-and-push-cib.yml
+++ b/tasks/create-and-push-cib.yml
@@ -65,7 +65,8 @@
         @name="cluster-name" or
         @name="dc-version" or
         @name="have-watchdog" or
-        @name="last-lrm-refresh"
+        @name="last-lrm-refresh" or
+        @name="stonith-watchdog-timeout"
       )]'
   environment:
     CIB_file: "{{ __ha_cluster_tempfile_cib_xml.path }}"

--- a/tasks/install-and-configure-packages.yml
+++ b/tasks/install-and-configure-packages.yml
@@ -32,6 +32,8 @@
     name: "{{
       __ha_cluster_fullstack_node_packages
       +
+      ha_cluster_sbd_enabled | ternary(__ha_cluster_sbd_packages, [])
+      +
       ha_cluster_fence_agent_packages
       +
       ha_cluster_extra_packages

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -55,6 +55,11 @@
     - name: Enable or disable cluster services on boot
       include_tasks: cluster-enable-disable.yml
 
+    - name: Configure SBD
+      include_tasks: sbd.yml
+      when:
+        - ha_cluster_sbd_enable
+
     - name: Pcs auth
       # Auth is run after corosync.conf has been distributed so that pcs
       # distributes pcs tokens in the cluster automatically.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,33 +32,20 @@
     - name: Distribute fence-virt authkey
       include_tasks: distribute-fence-virt-key.yml
 
-    - name: Configure cluster nodes
-      include_tasks: cluster-setup.yml
-
     # TODO: implement qdevice detection once qdevice is supported by the role
-    # - name: Fetch corosync quorum configuration
-    #   command:
-    #     cmd: pcs quorum config
-    #   register: __ha_cluster_pcs_quorum_config
-    #   run_once: yes
-    #   check_mode: no
-    #   changed_when: no
-    #   # This reads corosync.conf from the nodes. The file is not sent to the
-    #   # nodes in check mode.
-    #   when: not ansible_check_mode
-
     - name: Check if qdevice is configured
       set_fact:
         __ha_cluster_qdevice_in_use: no
       run_once: yes
 
-    - name: Enable or disable cluster services on boot
-      include_tasks: cluster-enable-disable.yml
-
     - name: Configure SBD
       include_tasks: sbd.yml
-      when:
-        - ha_cluster_sbd_enable
+
+    - name: Configure cluster nodes
+      include_tasks: cluster-setup.yml
+
+    - name: Enable or disable cluster services on boot
+      include_tasks: cluster-enable-disable.yml
 
     - name: Pcs auth
       # Auth is run after corosync.conf has been distributed so that pcs

--- a/tasks/sbd.yml
+++ b/tasks/sbd.yml
@@ -25,7 +25,7 @@
 
 - name: Enable softdog module
   copy:
-    content: "softdog"
+    content: softdog
     dest: /etc/modules-load.d/softdog.conf
     owner: root
     group: root

--- a/tasks/sbd.yml
+++ b/tasks/sbd.yml
@@ -10,6 +10,7 @@
 #   when:
 #     - ha_cluster_sbd_devices
 
+# TODO: deadlock if SBD was working before and cluster was stopped
 - name: Create SBD devices
   command: sbd -d {{ item }} {{ ha_cluster_sbd_create_params }} create
   run_once: true

--- a/tasks/sbd.yml
+++ b/tasks/sbd.yml
@@ -1,22 +1,22 @@
 # SPDX-License-Identifier: MIT
 ---
-# TODO: make creating SBD headers idempotent
-# - name: Check SBD device headers
-#   command: "sbd -d {{ item }}  dump"
-#   run_once: true
-#   ignore_errors: true
-#   register: "sbd_dump_{{ item }}"
-#   loop: "{{ ha_cluster_sbd_devices }}"
-#   when:
-#     - ha_cluster_sbd_devices
-
-# TODO: deadlock if SBD was working before and cluster was stopped
-- name: Create SBD devices
-  command: sbd -d {{ item }} {{ ha_cluster_sbd_create_params }} create
+- name: Check SBD device headers
+  command: "sbd -d {{ item }} dump"
   run_once: true
+  ignore_errors: true
+  changed_when: false
+  register: "sbd_dump"
   loop: "{{ ha_cluster_sbd_devices }}"
   when:
     - ha_cluster_sbd_devices
+
+- name: Create SBD devices
+  command: sbd -d {{ item.item }} {{ ha_cluster_sbd_create_params }} create
+  loop: "{{ sbd_dump['results'] }}"
+  when:
+    - item.rc == 1
+    - ha_cluster_sbd_devices
+  run_once: true
 
 - name: Enable softdog module
   copy:
@@ -36,11 +36,10 @@
     mode: '0644'
   when: ha_cluster_sbd_devices
 
-- name: Enable and start SBD
+- name: Enable SBD
   service:
     name: sbd
     enabled: true
-    state: started
 
 # TODO: automatically create stonith fence resources
 #       e.g. via pcs-cib-resource-create-pcs-0.10.yml?

--- a/tasks/sbd.yml
+++ b/tasks/sbd.yml
@@ -26,18 +26,13 @@
     mode: '0644'
   notify: Load softdog module
 
-- name: Set SBD parameters
-  replace:
-    path: /etc/sysconfig/sbd
-    regexp: "{{ item.regexp }}"
-    replace: "{{ item.replace }}"
-  loop:
-    - regexp: '^(.*)SBD_DEVICE=(.*)$'
-      replace: 'SBD_DEVICE="{{ ha_cluster_sbd_devices | join(";") }}"'
-    - regexp: '^(.*)SBD_OPTS=(.*)$'
-      replace: SBD_OPTS="{{ ha_cluster_sbd_daemon_params }}"
-    - regexp: '^(.*)SBD_STARTMODE=(.*)$' 
-      replace: "SBD_STARTMODE={{ ha_cluster_sbd_startmode }}"
+- name: Create SBD configuration file
+  template:
+    src: templates/sbd.j2
+    dest: /etc/sysconfig/sbd
+    owner: root
+    group: root
+    mode: '0644'
   when: ha_cluster_sbd_devices
 
 - name: Enable and start SBD

--- a/tasks/sbd.yml
+++ b/tasks/sbd.yml
@@ -11,7 +11,7 @@
 #     - ha_cluster_sbd_devices
 
 - name: Create SBD devices
-  command: "sbd -d {{ item }} {{ ha_cluster_sbd_create_params }} create"
+  command: sbd -d {{ item }} {{ ha_cluster_sbd_create_params }} create
   run_once: true
   loop: "{{ ha_cluster_sbd_devices }}"
   when:

--- a/tasks/sbd.yml
+++ b/tasks/sbd.yml
@@ -1,45 +1,88 @@
 # SPDX-License-Identifier: MIT
 ---
-- name: Check SBD device headers
-  command: "sbd -d {{ item }} dump"
-  run_once: true
-  ignore_errors: true
-  changed_when: false
-  register: "sbd_dump"
-  loop: "{{ ha_cluster_sbd_devices }}"
-  when:
-    - ha_cluster_sbd_devices
+- block:
+    - block:
+        - name: Probe SBD devices
+          command:
+            cmd: sbd -d {{ item | quote }} dump
+          loop: "{{ ha_cluster.sbd_devices | default([]) }}"
+          register: __ha_cluster_check_sbd_devices_result
+          changed_when: no
+          # return_code == 0 means the disk is initialized already
+          # return_code != 0 means the disk is not initialized yet
+          failed_when: no
+          # This command doesn't do any changes and so can safely be executed
+          # even in check_mode.
+          check_mode: no
 
-- name: Create SBD devices
-  command: sbd -d {{ item.item }} {{ ha_cluster_sbd_create_params }} create
-  loop: "{{ sbd_dump['results'] }}"
-  when:
-    - item.rc == 1
-    - ha_cluster_sbd_devices
-  run_once: true
+        - name: Initialize SBD devices
+          command:
+            # use --force to skip interactive confirmation
+            cmd: >
+              pcs --force -- stonith sbd device setup
+              device={{ item.item | quote }}
+              {% for option in ha_cluster_sbd_options | default([]) %}
+                {% if option.name == 'watchdog-timeout' %}
+                  watchdog-timeout={{ option.value | quote }}
+                  msgwait-timeout={{ option.value * 2 }}
+                {% endif %}
+              {% endfor %}
+          # The initialization is done only if a device has not been
+          # initialized already. Therefore this task always makes a change.
+          changed_when: yes
+          loop: "{{ __ha_cluster_check_sbd_devices_result.results }}"
+          when: item.rc != 0
+      # All nodes must have access to all SBD devices, otherwise SBD won't
+      # work. Therefore it is enough to run devices initialization on one node
+      # only. That way, we also avoid race conditions by initializing one
+      # device from multiple nodes at once.
+      run_once: yes
 
-- name: Enable softdog module
-  copy:
-    content: softdog
-    dest: /etc/modules-load.d/softdog.conf
-    owner: root
-    group: root
-    mode: '0644'
-  notify: Load softdog module
+    - name: Distribute SBD config
+      template:
+        src: templates/sbd
+        dest: /etc/sysconfig/sbd
+        owner: root
+        group: root
+        mode: 0644
+      vars:
+        options: "{{ ha_cluster_sbd_options | default([]) }}"
+        node_name: "{{ __ha_cluster_node_name }}"
+        node_watchdog: "{{
+            ha_cluster.sbd_watchdog | default('/dev/watchdog')
+          }}"
+        node_devices: "{{ ha_cluster.sbd_devices | default([]) }}"
+      register: __ha_cluster_distribute_sbd_config
 
-- name: Create SBD configuration file
-  template:
-    src: templates/sbd.j2
-    dest: /etc/sysconfig/sbd
-    owner: root
-    group: root
-    mode: '0644'
-  when: ha_cluster_sbd_devices
+    - name: Figure out if ATB needs to be enabled for SBD
+      set_fact:
+        # SBD needs ATB enabled if all of these are true:
+        # - sbd does not use devices (In check-and-prepare-role-variables.yml it
+        #   is verified that all nodes have the same number of devices defined.
+        #   Therefore it is enough to check devices of any single node.)
+        # - number of nodes is even
+        # - qdevice is not used
+        __ha_cluster_sbd_needs_atb: "{{
+            not ha_cluster.sbd_devices | default([])
+            and __ha_cluster_all_node_names | length is even
+            and not __ha_cluster_qdevice_in_use
+          }}"
 
-- name: Enable SBD
-  service:
-    name: sbd
-    enabled: true
+  when: ha_cluster_sbd_enabled
 
-# TODO: automatically create stonith fence resources
-#       e.g. via pcs-cib-resource-create-pcs-0.10.yml?
+- name: Get services status - detect pacemaker
+  service_facts:
+
+- name: Set stonith-watchdog-timeout cluster property
+  command:
+    cmd: >
+      pcs --force
+      {{
+        (
+          ansible_facts.services['pacemaker.service']['state'] | default()
+          == 'running'
+        ) | ternary('', '-f /var/lib/pacemaker/cib/cib.xml')
+      }}
+      -- property set
+      stonith-watchdog-timeout={{ ha_cluster_sbd_enabled | ternary('', '0') }}
+  changed_when: yes

--- a/tasks/sbd.yml
+++ b/tasks/sbd.yml
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: MIT
+---
+# TODO: make creating SBD headers idempotent
+# - name: Check SBD device headers
+#   command: "sbd -d {{ item }}  dump"
+#   run_once: true
+#   ignore_errors: true
+#   register: "sbd_dump_{{ item }}"
+#   loop: "{{ ha_cluster_sbd_devices }}"
+#   when:
+#     - ha_cluster_use_sbd
+#     - ha_cluster_sbd_devices
+#   tags:
+#     - sbd
+
+- name: Create SBD devices
+  command: "sbd -d {{ item }} {{ ha_cluster_sbd_create_params }} create"
+  run_once: true
+  loop: "{{ ha_cluster_sbd_devices }}"
+  when:
+    - ha_cluster_use_sbd
+    - ha_cluster_sbd_devices
+  tags:
+    - sbd
+
+- name: Enable softdog module
+  copy:
+    content: "softdog"
+    dest: /etc/modules-load.d/softdog.conf
+    owner: root
+    group: root
+    mode: '0644'
+  notify: Load softdog module
+  tags:
+    - sbd
+
+- name: Set SBD parameters
+  replace:
+    path: /etc/sysconfig/sbd
+    regexp: "{{ item.regexp }}"
+    replace: "{{ item.replace }}"
+  loop:
+    - regexp: '^(.*)SBD_DEVICE=(.*)$'
+      replace: 'SBD_DEVICE="{{ ha_cluster_sbd_devices | join(";") }}"'
+    - regexp: '^(.*)SBD_OPTS=(.*)$'
+      replace: SBD_OPTS="{{ ha_cluster_sbd_daemon_params }}"
+    - regexp: '^(.*)SBD_STARTMODE=(.*)$' 
+      replace: "SBD_STARTMODE={{ ha_cluster_sbd_startmode }}"
+  tags:
+    - sbd
+
+- name: Enable and start SBD
+  service:
+    name: sbd
+    enabled: true
+    state: started
+  tags:
+    - sbd
+
+# TODO: automatically create stonith fence resources
+#       e.g. via pcs-cib-resource-create-pcs-0.10.yml?

--- a/tasks/sbd.yml
+++ b/tasks/sbd.yml
@@ -9,8 +9,6 @@
 #   loop: "{{ ha_cluster_sbd_devices }}"
 #   when:
 #     - ha_cluster_sbd_devices
-#   tags:
-#     - sbd
 
 - name: Create SBD devices
   command: "sbd -d {{ item }} {{ ha_cluster_sbd_create_params }} create"
@@ -18,8 +16,6 @@
   loop: "{{ ha_cluster_sbd_devices }}"
   when:
     - ha_cluster_sbd_devices
-  tags:
-    - sbd
 
 - name: Enable softdog module
   copy:
@@ -29,8 +25,6 @@
     group: root
     mode: '0644'
   notify: Load softdog module
-  tags:
-    - sbd
 
 - name: Set SBD parameters
   replace:
@@ -45,16 +39,12 @@
     - regexp: '^(.*)SBD_STARTMODE=(.*)$' 
       replace: "SBD_STARTMODE={{ ha_cluster_sbd_startmode }}"
   when: ha_cluster_sbd_devices
-  tags:
-    - sbd
 
 - name: Enable and start SBD
   service:
     name: sbd
     enabled: true
     state: started
-  tags:
-    - sbd
 
 # TODO: automatically create stonith fence resources
 #       e.g. via pcs-cib-resource-create-pcs-0.10.yml?

--- a/tasks/sbd.yml
+++ b/tasks/sbd.yml
@@ -32,11 +32,15 @@
           changed_when: yes
           loop: "{{ __ha_cluster_check_sbd_devices_result.results }}"
           when: item.rc != 0
-      # All nodes must have access to all SBD devices, otherwise SBD won't
-      # work. Therefore it is enough to run devices initialization on one node
-      # only. That way, we also avoid race conditions by initializing one
-      # device from multiple nodes at once.
-      run_once: yes
+      # Ideally, the block as a whole should run one node at a time. This does
+      # not seem to be posible with Ansible yet. Instead, we at least make the
+      # block's tasks run one by one. This way, we avoid possible issues caused
+      # by initializing one device from multiple host at the same time. Devices
+      # initialized before the role started will not be reinitialized. Devices
+      # not initilized before the role started will be initialized as many
+      # times as there are nodes. That, however, has no other side effect than
+      # suboptimal performance of the role.
+      throttle: 1
 
     - name: Distribute SBD config
       template:

--- a/tasks/sbd.yml
+++ b/tasks/sbd.yml
@@ -8,7 +8,6 @@
 #   register: "sbd_dump_{{ item }}"
 #   loop: "{{ ha_cluster_sbd_devices }}"
 #   when:
-#     - ha_cluster_use_sbd
 #     - ha_cluster_sbd_devices
 #   tags:
 #     - sbd
@@ -18,7 +17,6 @@
   run_once: true
   loop: "{{ ha_cluster_sbd_devices }}"
   when:
-    - ha_cluster_use_sbd
     - ha_cluster_sbd_devices
   tags:
     - sbd
@@ -46,6 +44,7 @@
       replace: SBD_OPTS="{{ ha_cluster_sbd_daemon_params }}"
     - regexp: '^(.*)SBD_STARTMODE=(.*)$' 
       replace: "SBD_STARTMODE={{ ha_cluster_sbd_startmode }}"
+  when: ha_cluster_sbd_devices
   tags:
     - sbd
 

--- a/templates/sbd
+++ b/templates/sbd
@@ -1,11 +1,13 @@
-# {{ ansible_managed }}
-{%- macro option(ansible_name, default_value) -%}
+{{ ansible_managed | comment }}
+
+{% macro option(ansible_name, default_value) -%}
   {%- for option in options if option.name == ansible_name -%}
     {{ option.value }}
   {%- else -%}
     {{ default_value }}
   {%- endfor -%}
-{%- endmacro -%}
+{%- endmacro %}
+
 ## Type: string
 ## Default: ""
 #

--- a/templates/sbd
+++ b/templates/sbd
@@ -1,4 +1,11 @@
 # {{ ansible_managed }}
+{%- macro option(ansible_name, default_value) -%}
+  {%- for option in options if option.name == ansible_name -%}
+    {{ option.value }}
+  {%- else -%}
+    {{ default_value }}
+  {%- endfor -%}
+{%- endmacro -%}
 ## Type: string
 ## Default: ""
 #
@@ -6,7 +13,11 @@
 # and to monitor. If specifying more than one path, use ";" as
 # separator.
 #
-SBD_DEVICE="{{ ha_cluster_sbd_devices | join(';') }}"
+{% if node_devices | default([]) %}
+SBD_DEVICE="{{ node_devices | join(';') }}"
+{% else %}
+SBD_DEVICE=""
+{% endif %}
 
 ## Type: yesno
 ## Default: yes
@@ -22,7 +33,7 @@ SBD_PACEMAKER=yes
 # allow sbd to start if it was not previously fenced. See the -S option
 # in the man page.
 #
-SBD_STARTMODE={{ ha_cluster_sbd_startmode }}
+SBD_STARTMODE="{{ option('startmode', 'always') }}"
 
 ## Type: yesno / integer
 ## Default: no
@@ -46,7 +57,7 @@ SBD_STARTMODE={{ ha_cluster_sbd_startmode }}
 # This option may be ignored at a later point, once pacemaker handles
 # this case better.
 #
-SBD_DELAY_START=no
+SBD_DELAY_START="{{ option('delay-start', 'no') }}"
 
 ## Type: string
 ## Default: /dev/watchdog
@@ -54,7 +65,7 @@ SBD_DELAY_START=no
 # Watchdog device to use. If set to /dev/null, no watchdog device will
 # be used.
 #
-SBD_WATCHDOG_DEV=/dev/watchdog
+SBD_WATCHDOG_DEV="{{ node_watchdog | default('/dev/watchdog') }}"
 
 ## Type: integer
 ## Default: 5
@@ -72,7 +83,7 @@ SBD_WATCHDOG_DEV=/dev/watchdog
 # Be aware that watchdog timeout set in the on-disk metadata takes
 # precedence.
 #
-SBD_WATCHDOG_TIMEOUT=5
+SBD_WATCHDOG_TIMEOUT="{{ option('watchdog-timeout', '5') }}"
 
 ## Type: string
 ## Default: "flush,reboot"
@@ -90,7 +101,7 @@ SBD_WATCHDOG_TIMEOUT=5
 # And it does as well not configure the action a watchdog would
 # trigger should it run off (there is no generic interface).
 #
-SBD_TIMEOUT_ACTION=flush,reboot
+SBD_TIMEOUT_ACTION="{{ option('timeout-action', 'flush,reboot') }}"
 
 ## Type: yesno / auto
 ## Default: auto
@@ -131,4 +142,4 @@ SBD_SYNC_RESOURCE_STARTUP=yes
 #
 # Additional options for starting sbd
 #
-SBD_OPTS="{{ ha_cluster_sbd_daemon_params }}"
+SBD_OPTS="-n {{ node_name }}"

--- a/templates/sbd.j2
+++ b/templates/sbd.j2
@@ -1,0 +1,134 @@
+# {{ ansible_managed }}
+## Type: string
+## Default: ""
+#
+# SBD_DEVICE specifies the devices to use for exchanging sbd messages
+# and to monitor. If specifying more than one path, use ";" as
+# separator.
+#
+SBD_DEVICE="{{ ha_cluster_sbd_devices | join(';') }}"
+
+## Type: yesno
+## Default: yes
+#
+# Whether to enable the pacemaker integration.
+#
+SBD_PACEMAKER=yes
+
+## Type: always / clean
+## Default: always
+#
+# Specify the start mode for sbd. Setting this to "clean" will only
+# allow sbd to start if it was not previously fenced. See the -S option
+# in the man page.
+#
+SBD_STARTMODE={{ ha_cluster_sbd_startmode }}
+
+## Type: yesno / integer
+## Default: no
+#
+# Whether to delay after starting sbd on boot for "msgwait" seconds.
+# This may be necessary if your cluster nodes reboot so fast that the
+# other nodes are still waiting in the fence acknowledgement phase.
+# This is an occasional issue with virtual machines.
+#
+# This can also be enabled by being set to a specific delay value, in
+# seconds. Sometimes a longer delay than the default, "msgwait", is
+# needed, for example in the cases where it's considered to be safer to
+# wait longer than:
+# corosync token timeout + consensus timeout + pcmk_delay_max + msgwait
+#
+# Be aware that the special value "1" means "yes" rather than "1s".
+#
+# Consider that you might have to adapt the startup-timeout accordingly
+# if the default isn't sufficient. (TimeoutStartSec for systemd)
+#
+# This option may be ignored at a later point, once pacemaker handles
+# this case better.
+#
+SBD_DELAY_START=no
+
+## Type: string
+## Default: /dev/watchdog
+#
+# Watchdog device to use. If set to /dev/null, no watchdog device will
+# be used.
+#
+SBD_WATCHDOG_DEV=/dev/watchdog
+
+## Type: integer
+## Default: 5
+#
+# How long, in seconds, the watchdog will wait before panicking the
+# node if no-one tickles it.
+#
+# This depends mostly on your storage latency; the majority of devices
+# must be successfully read within this time, or else the node will
+# self-fence.
+#
+# If your sbd device(s) reside on a multipath setup or iSCSI, this
+# should be the time required to detect a path failure.
+#
+# Be aware that watchdog timeout set in the on-disk metadata takes
+# precedence.
+#
+SBD_WATCHDOG_TIMEOUT=5
+
+## Type: string
+## Default: "flush,reboot"
+#
+# Actions to be executed when the watchers don't timely report to the sbd
+# master process or one of the watchers detects that the master process
+# has died.
+#
+# Set timeout-action to comma-separated combination of
+# noflush|flush plus reboot|crashdump|off.
+# If just one of both is given the other stays at the default.
+#
+# This doesn't affect actions like off, crashdump, reboot explicitly
+# triggered via message slots.
+# And it does as well not configure the action a watchdog would
+# trigger should it run off (there is no generic interface).
+#
+SBD_TIMEOUT_ACTION=flush,reboot
+
+## Type: yesno / auto
+## Default: auto
+#
+# If CPUAccounting is enabled default is not to assign any RT-budget
+# to the system.slice which prevents sbd from running RR-scheduled.
+#
+# One way to escape that issue is to move sbd-processes from the
+# slice they were originally started to root-slice.
+# Of course starting sbd in a certain slice might be intentional.
+# Thus in auto-mode sbd will check if the slice has RT-budget assigned.
+# If that is the case sbd will stay in that slice while it will
+# be moved to root-slice otherwise.
+#
+SBD_MOVE_TO_ROOT_CGROUP=auto
+
+## Type: yesno
+## Default: yes
+#
+# If resource startup syncing is enabled then pacemakerd is
+# gonna wait to be pinged via IPC before it starts resources.
+# On shutdown pacemakerd is going to wait in a state where it
+# has cleanly shutdown resources till sbd fetches that state.
+#
+# The default is set when building SBD and Pacemaker from source.
+# Going for 'no' is safer if it can't be assured that SBD and
+# Pacemaker installed do both support the synchronization feature.
+# When going with 'yes' - also using package dependencies to
+# assure SBD & Pacemaker both support the synchronization
+# feature and are assuming the same default - an SBD configuration
+# inherited via an upgrade doesn't have to be altered to still
+# benefit from the new feature.
+#
+SBD_SYNC_RESOURCE_STARTUP=yes
+
+## Type: string
+## Default: ""
+#
+# Additional options for starting sbd
+#
+SBD_OPTS="{{ ha_cluster_sbd_daemon_params }}"

--- a/tests/tasks/cleanup_sbd.yml
+++ b/tests/tasks/cleanup_sbd.yml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Unount SBD devices
+  command:
+    cmd: losetup -d {{ __test_sbd_mount.stdout }}
+  changed_when: yes
+
+- name: Delete backing files for SBD devices
+  file:
+    path: "{{ __test_sbd_tmpfile }}"
+    state: absent

--- a/tests/tasks/setup_sbd.yml
+++ b/tests/tasks/setup_sbd.yml
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Load softdog module for SBD to have at least one watchdog
+  command: modprobe softdog
+  changed_when: yes
+
+- name: Create backing files for SBD devices
+  tempfile:
+    state: file
+    suffix: _ha_cluster_tests
+  register: __test_sbd_tmpfile
+
+- name: Initialize backing files for SBD devices
+  command:
+    cmd: dd if=/dev/zero of={{ __test_sbd_tmpfile.path | quote }} bs=1M count=10
+  changed_when: yes
+
+- name: Mount SBD devices
+  command:
+    cmd: losetup --show --find {{ __test_sbd_tmpfile.path | quote }}
+  register: __test_sbd_mount
+  changed_when: yes

--- a/tests/tests_cib_constraints_create.yml
+++ b/tests/tests_cib_constraints_create.yml
@@ -394,6 +394,26 @@
         - name: Fetch cluster versions of cluster components
           include_tasks: tasks/fetch_versions.yml
 
+        - name: Dicover CIB schema version
+          command:
+            cmd: >
+              xmllint
+              --xpath 'substring-after(/cib/@validate-with, "pacemaker-")'
+              /var/lib/pacemaker/cib/cib.xml
+          register: __test_cib_validate_with
+          changed_when: no
+
+        - name: Discover role names
+          set_fact:
+            __test_new_roles_pcs: "{{
+                __test_pcs_version is version('0.11', '>=')
+              }}"
+            __test_new_roles_cib: "{{
+                __test_pcs_version is version('0.11', '>=')
+                and
+                __test_cib_validate_with.stdout is version('3.7', '>=')
+              }}"
+
         # yamllint disable rule:line-length
         - block:
             - name: Fetch location constraints configuration from the cluster
@@ -416,7 +436,7 @@
                   - __test_pcs_location_config.stdout_lines == __test_expected_lines | select | list
           vars:
             __test_role_promoted: "{%
-                if __test_pcs_version is version('0.11', '>=')
+                if __test_new_roles_pcs
                   %}Promoted{%
                 elif 'pcmk.cib.roles.promoted-unpromoted' in __test_pcs_capabilities
                   %}Master{%
@@ -425,7 +445,7 @@
                 endif
                 %}"
             __test_role_unpromoted: "{%
-                if __test_pcs_version is version('0.11', '>=')
+                if __test_new_roles_pcs
                   %}Unpromoted{%
                 elif 'pcmk.cib.roles.promoted-unpromoted' in __test_pcs_capabilities
                   %}Slave{%
@@ -542,18 +562,18 @@
               - '  d2 with d3 (score:-10) (id:colocation-d2-d3--10)'
               - '  d3 with d4 (score:INFINITY) (id:cc-id)'
               - "  d1 with d3 (score:INFINITY) (rsc-role:{{
-                  __test_pcs_version is version('0.11', '>=') | ternary('Promoted', 'Master')
+                  __test_new_roles_pcs | ternary('Promoted', 'Master')
                   }}) (with-rsc-role:{{
-                  __test_pcs_version is version('0.11', '>=') | ternary('Promoted', 'Master')
+                  __test_new_roles_pcs | ternary('Promoted', 'Master')
                   }}) (id:colocation-d1-d3-INFINITY)"
               - '  d1 with d4 (score:INFINITY) (node-attribute:attribute-name) (id:colocation-d1-d4-INFINITY)'
               - "  d2 with d4 (score:-INFINITY) (node-attribute:attribute-name) (rsc-role:{{
-                  __test_pcs_version is version('0.11', '>=') | ternary('Unpromoted', 'Slave')
+                  __test_new_roles_pcs | ternary('Unpromoted', 'Slave')
                   }}) (with-rsc-role:Started) (id:cc-all)"
               - '  Resource Sets:'
               - '    set d1 d2 (id:colocation_set_d1d2_set) setoptions score=INFINITY (id:colocation_set_d1d2)'
               - "    set d1 d2 role={{
-                  __test_pcs_version is version('0.11', '>=') | ternary('Promoted', 'Master')
+                  __test_new_roles_pcs | ternary('Promoted', 'Master')
                   }} (id:cc-set_set) set d3 d4 sequential=false (id:cc-set_set-1) setoptions score=20 (id:cc-set)"
 
         - block:
@@ -613,13 +633,13 @@
               - '  d1 ticket=ticket1 (id:ticket-ticket1-d1)'
               - '  d1 ticket=ticket2 (id:ct-id)'
               - "  {{
-                  __test_pcs_version is version('0.11', '>=') | ternary('Promoted', 'Master')
+                  __test_new_roles_pcs | ternary('Promoted', 'Master')
                   }} d2 ticket=ticket1 (id:ticket-ticket1-d2-{{
-                  __test_pcs_version is version('0.11', '>=') | ternary('Promoted', 'Master')
+                  __test_new_roles_cib | ternary('Promoted', 'Master')
                   }})"
               - '  d2 loss-policy=stop ticket=ticket2 (id:ticket-ticket2-d2)'
               - "  {{
-                  __test_pcs_version is version('0.11', '>=') | ternary('Unpromoted', 'Slave')
+                  __test_new_roles_pcs | ternary('Unpromoted', 'Slave')
                   }} d3 loss-policy=demote ticket=ticket3 (id:ct-all)"
               - '  Resource Sets:'
               - '    set d1 (id:ticket_set_d1_set) setoptions ticket=ticket-set1 (id:ticket_set_d1)'

--- a/tests/tests_sbd_all_options.yml
+++ b/tests/tests_sbd_all_options.yml
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Maximal SBD configuration
+  hosts: all
+  vars_files: vars/main.yml
+  vars:
+    ha_cluster_cluster_name: test-cluster
+    ha_cluster_sbd_enabled: yes
+    ha_cluster_sbd_options:
+      - name: delay-start
+        value: 2s
+      - name: startmode
+        value: clean
+      - name: timeout-action
+        value: reboot,flush
+      - name: watchdog-timeout
+        value: 10
+
+  tasks:
+    - block:
+        - name: Set up test environment
+          include_tasks: tasks/setup_test.yml
+
+        - name: Set up test environment for SBD
+          include_tasks: tasks/setup_sbd.yml
+
+        - name: Set SBD devices and watchdogs
+          set_fact:
+            ha_cluster:
+              sbd_watchdog: /dev/null
+              sbd_devices:
+                - "{{ __test_sbd_mount.stdout }}"
+
+        - name: Run HA Cluster role
+          include_role:
+            name: linux-system-roles.ha_cluster
+
+        - name: Slurp SBD config file
+          slurp:
+            src: /etc/sysconfig/sbd
+          register: __test_sbd_config
+
+        - name: Decode SBD config
+          set_fact:
+            __test_sbd_config_lines: "{{
+                (__test_sbd_config.content | b64decode).splitlines()
+              }}"
+
+        - name: Print SBD config lines
+          debug:
+            var: __test_sbd_config_lines
+
+        - name: Check SBD config
+          assert:
+            that:
+              - "'SBD_DELAY_START=\"2s\"' in __test_sbd_config_lines"
+              - "'SBD_DEVICE=\"{{ __test_sbd_mount.stdout }}\"'
+                in __test_sbd_config_lines"
+              - "'SBD_STARTMODE=\"clean\"' in __test_sbd_config_lines"
+              - "'SBD_TIMEOUT_ACTION=\"reboot,flush\"'
+                in __test_sbd_config_lines"
+              - "'SBD_WATCHDOG_DEV=\"/dev/null\"' in __test_sbd_config_lines"
+              - "'SBD_WATCHDOG_TIMEOUT=\"10\"' in __test_sbd_config_lines"
+              - >
+                __test_sbd_config_lines[-1]
+                == 'SBD_OPTS="-n {{ __ha_cluster_node_name }}"'
+
+      always:
+        - name: Unset SBD devices and watchdogs
+          set_fact:
+            ha_cluster:
+
+        - name: Clean up test environment for SBD
+          include_tasks: tasks/cleanup_sbd.yml
+      tags: tests::verify

--- a/tests/tests_sbd_check_devices_count.yml
+++ b/tests/tests_sbd_check_devices_count.yml
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Ensure all nodes have the same number of SBD devices
+  hosts: all
+  vars_files: vars/main.yml
+  vars:
+    ha_cluster_sbd_enabled: yes
+
+  tasks:
+    - block:
+        - name: Set up test environment
+          include_tasks: tasks/setup_test.yml
+
+        - name: Set SBD devices variable
+          set_fact:
+            ha_cluster:
+              sbd_devices: "{{
+                  range(1, ansible_play_hosts_all.index(inventory_hostname) + 2)
+                  | product(['/tmp/dev/sdx']) | map('reverse') | map('join')
+                  | list
+                }}"
+
+        - name: Print set SBD devices
+          debug:
+            var: ha_cluster.sbd_devices
+
+        - block:
+            - name: Run the role
+              include_role:
+                name: linux-system-roles.ha_cluster
+          rescue:
+            - name: Check errors
+              assert:
+                that: "{{
+                  ansible_failed_result.msg ==
+                  'All nodes must have the same number of SBD devices specified'
+                }}"
+              run_once: yes
+
+      when: ansible_play_hosts_all | length > 1
+      always:
+        - name: Unset SBD devices variable
+          set_fact:
+            ha_cluster:
+      tags: tests::verify
+
+    - name: Message
+      debug:
+        msg: This test needs two or more nodes
+      when: ansible_play_hosts_all | length <= 1

--- a/tests/tests_sbd_defaults.yml
+++ b/tests/tests_sbd_defaults.yml
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Minimal SBD configuration
+  hosts: all
+  vars_files: vars/main.yml
+  vars:
+    ha_cluster_cluster_name: test-cluster
+    ha_cluster_sbd_enabled: yes
+
+  tasks:
+    - block:
+        - name: Set up test environment
+          include_tasks: tasks/setup_test.yml
+
+        - name: Set up test environment for SBD
+          include_tasks: tasks/setup_sbd.yml
+
+        - name: Ensure SBD config file is not present
+          file:
+            path: /etc/sysconfig/sbd
+            state: absent
+
+        - name: Run HA Cluster role
+          include_role:
+            name: linux-system-roles.ha_cluster
+
+        - name: Slurp SBD config file
+          slurp:
+            src: /etc/sysconfig/sbd
+          register: __test_sbd_config
+
+        - name: Decode SBD config
+          set_fact:
+            __test_sbd_config_lines: "{{
+                (__test_sbd_config.content | b64decode).splitlines()
+              }}"
+
+        - name: Print SBD config lines
+          debug:
+            var: __test_sbd_config_lines
+
+        - name: Check SBD config
+          assert:
+            that:
+              - __test_sbd_config_lines[1] == "# Ansible managed"
+              - >
+                __test_sbd_config_lines[-1]
+                == 'SBD_OPTS="-n {{ __ha_cluster_node_name }}"'
+
+        - name: Fetch quorum configuration
+          command:
+            cmd: pcs quorum config
+          register: __test_quorum_config
+          changed_when: no
+
+        - name: Check auto tie breaker in quorum configuration
+          assert:
+            that:
+              - '(
+                  (
+                    ansible_play_hosts | length is even
+                    and "auto_tie_breaker: 1" in __test_quorum_lines
+                  )
+                  or
+                  (
+                    ansible_play_hosts | length is odd
+                    and "auto_tie_breaker: 1" not in __test_quorum_lines
+                  )
+                )'
+          vars:
+            __test_quorum_lines: "{{
+                __test_quorum_config.stdout_lines | map('trim') | list
+              }}"
+
+        - name: Get services status
+          service_facts:
+
+        - name: Check services status
+          assert:
+            that:
+              - ansible_facts.services["corosync.service"].status == "enabled"
+              - ansible_facts.services["pacemaker.service"].status == "enabled"
+              - ansible_facts.services["sbd.service"].status == "enabled"
+
+        - name: Check cluster status
+          include_tasks: tasks/assert_cluster_running.yml
+
+      always:
+        - name: Clean up test environment for SBD
+          include_tasks: tasks/cleanup_sbd.yml
+      tags: tests::verify

--- a/tests/tests_sbd_defaults_disabled.yml
+++ b/tests/tests_sbd_defaults_disabled.yml
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Minimal SBD configuration
+  hosts: all
+  vars_files: vars/main.yml
+  vars:
+    ha_cluster_cluster_name: test-cluster
+    ha_cluster_start_on_boot: no
+    ha_cluster_sbd_enabled: yes
+
+  tasks:
+    - block:
+        - name: Set up test environment
+          include_tasks: tasks/setup_test.yml
+
+        - name: Run HA Cluster role
+          include_role:
+            name: linux-system-roles.ha_cluster
+
+        - name: Get services status
+          service_facts:
+
+        - name: Check services status
+          assert:
+            that:
+              - ansible_facts.services["corosync.service"].status == "disabled"
+              - ansible_facts.services["pacemaker.service"].status == "disabled"
+              - ansible_facts.services["sbd.service"].status == "disabled"
+
+      tags: tests::verify

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -19,6 +19,9 @@ __ha_cluster_fullstack_node_packages:
   - pcs
   - openssl  # used in the role for generating preshared keys
 
+__ha_cluster_sbd_packages:
+  - sbd
+
 __ha_cluster_services:
   - corosync
   - corosync-qdevice


### PR DESCRIPTION
As discussed in #29 I started implementing my workarounds in order to support SBD.

This is **not** considered as *ready to merge*, yet. I was able to use this code in order to configure SBD on a 2-node cluster using the following code:

```yaml
- name: linux-system-roles.ha_cluster
  ha_cluster_cluster_name: "{{ cluster_name }}"
  ha_cluster_hacluster_password: "{{ cluster_password }}"
  ha_cluster_resource_primitives:
    - id: fence-sbd
      agent: 'stonith:fence_sbd'
      instance_attrs:
        - attrs:
            - name: devices
              value: /dev/sdb
  ha_cluster_resource_groups: "{{ cluster_groups }}"
  ha_cluster_sbd_enable: true
  ha_cluster_sbd_devices:
    - /dev/sdb
  ha_cluster_sbd_startmode: "clean"
```

Currently, there are still two TODOs:

- [x] make creating SBD headers on disk idempotent
- [ ] automatically configure SBD disks as PCS fence resources - currently this needs to be done manually, e.g. using the `ha_cluster_resource_primitives` variable (see above)