### PR TITLE
fix default pcsd permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ structure and default value:
 ```yaml
 ha_cluster_pcs_permission_list:
   - type: group
-    name: hacluster
+    name: haclient
     allow_list:
       - grant
       - read

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,7 +24,7 @@ ha_cluster_cluster_name: my-cluster
 
 ha_cluster_pcs_permission_list:
   - type: group
-    name: hacluster
+    name: haclient
     allow_list:
       - grant
       - read


### PR DESCRIPTION
Previously, permissions were set for 'hacluster' group. Correct name of the group is 'haclient'.