### PR TITLE
support gather_facts: false; support setup-snapshot.yml

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,19 +1,7 @@
 # SPDX-License-Identifier: MIT
 ---
 - name: Set platform/version specific variables
-  include_vars: "{{ __ha_cluster_vars_file }}"
-  loop:
-    - "{{ ansible_facts['os_family'] }}.yml"
-    - "{{ ansible_facts['distribution'] }}.yml"
-    - >-
-      {{ ansible_facts['distribution'] ~ '_' ~
-      ansible_facts['distribution_major_version'] }}.yml
-    - >-
-      {{ ansible_facts['distribution'] ~ '_' ~
-      ansible_facts['distribution_version'] }}.yml
-  vars:
-    __ha_cluster_vars_file: "{{ role_path }}/vars/{{ item }}"
-  when: __ha_cluster_vars_file is file
+  include_tasks: set_vars.yml
 
 - name: Check and prepare role variables
   include_tasks: check-and-prepare-role-variables.yml

--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -1,0 +1,21 @@
+---
+- name: Ensure ansible_facts used by role
+  setup:
+    gather_subset: min
+  when: not ansible_facts.keys() | list |
+    intersect(__ha_cluster_required_facts) == __ha_cluster_required_facts
+
+- name: Set platform/version specific variables
+  include_vars: "{{ __vars_file }}"
+  loop:
+    - "{{ ansible_facts['os_family'] }}.yml"
+    - "{{ ansible_facts['distribution'] }}.yml"
+    - >-
+      {{ ansible_facts['distribution'] ~ '_' ~
+      ansible_facts['distribution_major_version'] }}.yml
+    - >-
+      {{ ansible_facts['distribution'] ~ '_' ~
+      ansible_facts['distribution_version'] }}.yml
+  vars:
+    __vars_file: "{{ role_path }}/vars/{{ item }}"
+  when: __vars_file is file

--- a/tests/setup-snapshot.yml
+++ b/tests/setup-snapshot.yml
@@ -1,0 +1,20 @@
+- hosts: all
+  tasks:
+    - name: Set platform/version specific variables
+      include_role:
+        name: linux-system-roles.ha_cluster
+        tasks_from: set_vars.yml
+        public: true
+
+    - name: Install cluster packages
+      package:
+        name: "{{
+          __ha_cluster_fullstack_node_packages
+          +
+          ha_cluster_sbd_enabled | ternary(__ha_cluster_sbd_packages, [])
+          +
+          ha_cluster_fence_agent_packages
+          +
+          ha_cluster_extra_packages
+        }}"
+        state: present

--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -2,6 +2,7 @@
 ---
 - name: Ensure mandatory variables are defined
   hosts: all
+  gather_facts: false
   tasks:
     - block:
         - name: Run the role

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -29,3 +29,11 @@ __ha_cluster_services:
 
 # TODO: implement qdevice detection once qdevice is supported by the role
 __ha_cluster_qdevice_in_use: no
+
+# ansible_facts required by the role
+__ha_cluster_required_facts:
+  - architecture
+  - distribution
+  - distribution_major_version
+  - distribution_version
+  - os_family


### PR DESCRIPTION
Some users use `gather_facts: false` in their playbooks.  This changes
the role to work in that case, by gathering only the facts it requires
to run.
CI testing can be sped up by creating a snapshot image pre-installed
with packages.  tests/setup-snapshot.yml can be used by a CI system
to do this.
