### PR TITLE
additional fix for password_hash salt length

### DIFF
--- a/tasks/install-and-configure-packages.yml
+++ b/tasks/install-and-configure-packages.yml
@@ -48,7 +48,6 @@
     password: "{{
       ha_cluster_hacluster_password
       | password_hash(
-          'sha512',
-          ansible_hostname|replace('-','x')|truncate(16, True, '')
+          'sha512',  ansible_hostname.replace('-','x')[:16]
         )
     }}"


### PR DESCRIPTION
To make sure the string is strictly truncated at the given length, add leeway=0.

It looks `truncate` does not always truncate the string depending upon the length of the given string. In this example, when the length is 20, the entire string is kept without the 4th argument.

Sample test:
```
---
- name: set parameters for test
  hosts: localhost
  gather_facts: false
  vars:
    str_len_20: "01234567890123456789"
    str_len_22: "0123456789012345678901"
  tasks:
    - debug:
        msg: "str_len_20 truncate(16, True, '') {{ str_len_20|truncate(16, True, '') }}"

    - debug:
        msg: "str_len_20 truncate(16, True, '', 0) {{ str_len_20|truncate(16, True, '', 0) }}"

    - debug:
        msg: "str_len_22 truncate(16, True, '') {{ str_len_22|truncate(16, True, '') }}"

    - debug:
        msg: "str_len_22 truncate(16, True, '', 0) {{ str_len_22|truncate(16, True, '', 0) }}"
```
Results:
```
TASK [debug] **************************************************************************
ok: [localhost] => {
    "msg": "str_len_20 truncate(16, True, '') 01234567890123456789"
}

TASK [debug] **************************************************************************
ok: [localhost] => {
    "msg": "str_len_20 truncate(16, True, '', 0) 0123456789012345"
}

TASK [debug] **************************************************************************
ok: [localhost] => {
    "msg": "str_len_22 truncate(16, True, '') 0123456789012345"
}

TASK [debug] **************************************************************************
ok: [localhost] => {
    "msg": "str_len_22 truncate(16, True, '', 0) 0123456789012345"
}
```