### PR TITLE
s/ansible_play_hosts_all/ansible_play_hosts/ where applicable

### DIFF
--- a/tasks/check-and-prepare-role-variables.yml
+++ b/tasks/check-and-prepare-role-variables.yml
@@ -16,7 +16,7 @@
       when:
         - ha_cluster_sbd_enabled
         - >
-          ansible_play_hosts_all
+          ansible_play_hosts
           | map('extract', hostvars, ['ha_cluster', 'sbd_devices'])
           | map('default', [], true)
           | map('length') | unique | length > 1
@@ -32,7 +32,7 @@
 - name: Collect cluster node names
   set_fact:
     __ha_cluster_all_node_names: "{{
-        ansible_play_hosts_all
+        ansible_play_hosts
         | map('extract', hostvars, '__ha_cluster_node_name')
         | list
       }}"

--- a/tasks/cluster-setup-pcs-0.10.yml
+++ b/tasks/cluster-setup-pcs-0.10.yml
@@ -11,7 +11,7 @@
       {% endif %}
       --
       {{ ha_cluster_cluster_name | quote }}
-      {% for node in ansible_play_hosts_all %}
+      {% for node in ansible_play_hosts %}
         {{ hostvars[node].__ha_cluster_node_name | quote }}
         {%
           for addr in hostvars[node].ha_cluster.corosync_addresses | default([])

--- a/tasks/pcs-auth-pcs-0.10.yml
+++ b/tasks/pcs-auth-pcs-0.10.yml
@@ -6,7 +6,7 @@
     # pcs auth tokens in the cluster when not all nodes are auth-ed.
     cmd: >
       pcs host auth -u hacluster --
-      {% for node in ansible_play_hosts_all %}
+      {% for node in ansible_play_hosts %}
         {{ hostvars[node].__ha_cluster_node_name | quote }}
         {% if hostvars[node].ha_cluster.pcs_address | default("") %}
           addr={{ hostvars[node].ha_cluster.pcs_address | quote }}

--- a/tasks/pcs-auth.yml
+++ b/tasks/pcs-auth.yml
@@ -4,7 +4,7 @@
   command:
     cmd: >
       pcs status pcsd --
-      {% for node in ansible_play_hosts_all %}
+      {% for node in ansible_play_hosts %}
         {{ hostvars[node].__ha_cluster_node_name | quote }}
       {% endfor %}
   register: __ha_cluster_pcs_auth_status

--- a/tasks/presharedkey.yml
+++ b/tasks/presharedkey.yml
@@ -77,7 +77,7 @@
       # Following variables set the fact for all nodes
       delegate_facts: yes
       delegate_to: "{{ item }}"
-      with_items: "{{ ansible_play_hosts_all }}"
+      with_items: "{{ ansible_play_hosts }}"
   when:
     - not (preshared_key_src is string and preshared_key_src | length > 1)
     - not ha_cluster_regenerate_keys


### PR DESCRIPTION
The `ha_cluster` role is sometimes included within other roles.
In the scenario when a play is run against multiple hosts, and some of
them fail prior to including `ha_cluster`, `ha_cluster` must continue only
on the active hosts. Otherwise, `ha_cluster` tries to operate on failed nodes and fails.

From the [Special Variables](https://docs.ansible.com/ansible/latest/reference_appendices/special_variables.html) doc:
`ansible_play_hosts`: List of hosts in the current play run, not limited by the serial. Failed/Unreachable hosts are excluded from this list.
`ansible_play_hosts_all`: List of all the hosts that were targeted by the play
