### PR TITLE
use a real temporary directory for test secrets

### DIFF
--- a/tests/tasks/fixture_psks.yml
+++ b/tests/tasks/fixture_psks.yml
@@ -11,13 +11,6 @@
         state: present
       when: "'openssl' not in ansible_facts.packages"
 
-    - name: Ensure a directory for temporary files exists
-      file:
-        path: "{{ playbook_dir }}/tmp"
-        state: directory
-        mode: 0700
-
-
     - name: Generate a self signed pcsd cert and the pcsd key
       command: >-
         openssl req -x509 -newkey rsa:2048 -nodes
@@ -47,8 +40,8 @@
   delegate_to: localhost
   run_once: true
   vars:
-    __test_pcsd_private_key_path: "{{ playbook_dir }}/tmp/pcsd.key"
-    __test_pcsd_public_key_path: "{{ playbook_dir }}/tmp/pcsd.crt"
-    __test_corosync_key_path: "{{ playbook_dir }}/tmp/corosync-authkey"
-    __test_pacemaker_key_path: "{{ playbook_dir }}/tmp/pacemaker-authkey"
-    __test_fence_xvm_key_path: "{{ playbook_dir }}/tmp/fence_xvm.key"
+    __test_pcsd_private_key_path: "{{ __ha_cluster_work_dir.path }}/pcsd.key"
+    __test_pcsd_public_key_path: "{{ __ha_cluster_work_dir.path }}/pcsd.crt"
+    __test_corosync_key_path: "{{ __ha_cluster_work_dir.path }}/corosync-authkey"
+    __test_pacemaker_key_path: "{{ __ha_cluster_work_dir.path }}/pacemaker-authkey"
+    __test_fence_xvm_key_path: "{{ __ha_cluster_work_dir.path }}/fence_xvm.key"

--- a/tests/tasks/fixture_psks.yml
+++ b/tests/tasks/fixture_psks.yml
@@ -42,6 +42,8 @@
   vars:
     __test_pcsd_private_key_path: "{{ __ha_cluster_work_dir.path }}/pcsd.key"
     __test_pcsd_public_key_path: "{{ __ha_cluster_work_dir.path }}/pcsd.crt"
-    __test_corosync_key_path: "{{ __ha_cluster_work_dir.path }}/corosync-authkey"
-    __test_pacemaker_key_path: "{{ __ha_cluster_work_dir.path }}/pacemaker-authkey"
+    __test_corosync_key_path: >-
+      {{ __ha_cluster_work_dir.path }}/corosync-authkey
+    __test_pacemaker_key_path: >-
+      {{ __ha_cluster_work_dir.path }}/pacemaker-authkey
     __test_fence_xvm_key_path: "{{ __ha_cluster_work_dir.path }}/fence_xvm.key"

--- a/tests/tests_cluster_basic_custom_pcsd_tls.yml
+++ b/tests/tests_cluster_basic_custom_pcsd_tls.yml
@@ -5,11 +5,18 @@
   vars_files: vars/main.yml
   vars:
     ha_cluster_cluster_name: test-cluster
-    ha_cluster_pcsd_public_key_src: "{{ playbook_dir }}/tmp/pcsd.crt"
-    ha_cluster_pcsd_private_key_src: "{{ playbook_dir }}/tmp/pcsd.key"
+    ha_cluster_pcsd_public_key_src: "{{ __ha_cluster_work_dir.path }}/pcsd.crt"
+    ha_cluster_pcsd_private_key_src: "{{ __ha_cluster_work_dir.path }}/pcsd.key"
 
   tasks:
     - block:
+        - name: Create temp directory for secrets
+          tempfile:
+            state: directory
+            prefix: lsr_ha_cluster_
+          register: __ha_cluster_work_dir
+          delegate_to: localhost
+
         - name: Set up test environment
           include_role:
             name: linux-system-roles.ha_cluster
@@ -69,3 +76,9 @@
                 == stat_pcsd_key_expected.stat.checksum
 
       tags: tests::verify
+
+      always:
+        - name: Clean up work directory
+          file:
+            path: "{{ __ha_cluster_work_dir.path }}"
+            state: absent

--- a/tests/tests_cluster_basic_custom_pcsd_tls.yml
+++ b/tests/tests_cluster_basic_custom_pcsd_tls.yml
@@ -16,6 +16,7 @@
             prefix: lsr_ha_cluster_
           register: __ha_cluster_work_dir
           delegate_to: localhost
+          run_once: true
 
         - name: Set up test environment
           include_role:
@@ -82,3 +83,5 @@
           file:
             path: "{{ __ha_cluster_work_dir.path }}"
             state: absent
+          delegate_to: localhost
+          run_once: true

--- a/tests/tests_cluster_basic_existing_psks.yml
+++ b/tests/tests_cluster_basic_existing_psks.yml
@@ -7,8 +7,10 @@
     ha_cluster_cluster_name: test-cluster
     __test_pcsd_private_key_path: "{{ __ha_cluster_work_dir.path }}/pcsd.key"
     __test_pcsd_public_key_path: "{{ __ha_cluster_work_dir.path }}/pcsd.crt"
-    __test_corosync_key_path: "{{ __ha_cluster_work_dir.path }}/corosync-authkey"
-    __test_pacemaker_key_path: "{{ __ha_cluster_work_dir.path }}/pacemaker-authkey"
+    __test_corosync_key_path: >-
+      {{ __ha_cluster_work_dir.path }}/corosync-authkey
+    __test_pacemaker_key_path: >-
+      {{ __ha_cluster_work_dir.path }}/pacemaker-authkey
     __test_fence_xvm_key_path: "{{ __ha_cluster_work_dir.path }}/fence_xvm.key"
 
   tasks:

--- a/tests/tests_cluster_basic_existing_psks.yml
+++ b/tests/tests_cluster_basic_existing_psks.yml
@@ -21,6 +21,7 @@
             prefix: lsr_ha_cluster_
           register: __ha_cluster_work_dir
           delegate_to: localhost
+          run_once: true
 
         - name: Set up test environment
           include_role:
@@ -213,3 +214,5 @@
           file:
             path: "{{ __ha_cluster_work_dir.path }}"
             state: absent
+          delegate_to: localhost
+          run_once: true

--- a/tests/tests_cluster_basic_existing_psks.yml
+++ b/tests/tests_cluster_basic_existing_psks.yml
@@ -5,14 +5,21 @@
   vars_files: vars/main.yml
   vars:
     ha_cluster_cluster_name: test-cluster
-    __test_pcsd_private_key_path: "{{ playbook_dir }}/tmp/pcsd.key"
-    __test_pcsd_public_key_path: "{{ playbook_dir }}/tmp/pcsd.crt"
-    __test_corosync_key_path: "{{ playbook_dir }}/tmp/corosync-authkey"
-    __test_pacemaker_key_path: "{{ playbook_dir }}/tmp/pacemaker-authkey"
-    __test_fence_xvm_key_path: "{{ playbook_dir }}/tmp/fence_xvm.key"
+    __test_pcsd_private_key_path: "{{ __ha_cluster_work_dir.path }}/pcsd.key"
+    __test_pcsd_public_key_path: "{{ __ha_cluster_work_dir.path }}/pcsd.crt"
+    __test_corosync_key_path: "{{ __ha_cluster_work_dir.path }}/corosync-authkey"
+    __test_pacemaker_key_path: "{{ __ha_cluster_work_dir.path }}/pacemaker-authkey"
+    __test_fence_xvm_key_path: "{{ __ha_cluster_work_dir.path }}/fence_xvm.key"
 
   tasks:
     - block:
+        - name: Create temp directory for secrets
+          tempfile:
+            state: directory
+            prefix: lsr_ha_cluster_
+          register: __ha_cluster_work_dir
+          delegate_to: localhost
+
         - name: Set up test environment
           include_role:
             name: linux-system-roles.ha_cluster
@@ -59,23 +66,21 @@
             mode: 0400
           when: __test_fence_virt_supported
 
-        - name: Ensure pcsd TLS certificate and key exist
-          block:
-            - name: Distribute pcsd TLS private key
-              copy:
-                src: "{{ __test_pcsd_private_key_path }}"
-                dest: /var/lib/pcsd/pcsd.key
-                owner: root
-                group: root
-                mode: 0600
+        - name: Distribute pcsd TLS private key
+          copy:
+            src: "{{ __test_pcsd_private_key_path }}"
+            dest: /var/lib/pcsd/pcsd.key
+            owner: root
+            group: root
+            mode: 0600
 
-            - name: Distribute pcsd TLS certificate
-              copy:
-                src: "{{ __test_pcsd_public_key_path }}"
-                dest: /var/lib/pcsd/pcsd.crt
-                owner: root
-                group: root
-                mode: 0600
+        - name: Distribute pcsd TLS certificate
+          copy:
+            src: "{{ __test_pcsd_public_key_path }}"
+            dest: /var/lib/pcsd/pcsd.crt
+            owner: root
+            group: root
+            mode: 0600
 
         - name: Get corosync key hash
           stat:
@@ -200,3 +205,9 @@
           include_tasks: tasks/assert_cluster_running.yml
 
       tags: tests::verify
+
+      always:
+        - name: Clean up work directory
+          file:
+            path: "{{ __ha_cluster_work_dir.path }}"
+            state: absent

--- a/tests/tests_cluster_basic_new_psks.yml
+++ b/tests/tests_cluster_basic_new_psks.yml
@@ -11,7 +11,8 @@
     # generate a new TLS certificate - key pair for pcsd, even if there already
     #   is one
     ha_cluster_regenerate_keys: true
-    ha_cluster_corosync_key_src: "{{ __ha_cluster_work_dir.path }}/corosync-authkey"
+    ha_cluster_corosync_key_src: >-
+      {{ __ha_cluster_work_dir.path }}/corosync-authkey
     __test_pacemaker_key_content: key content to be replaced
     __test_pcsd_private_key_path: "{{ __ha_cluster_work_dir.path }}/pcsd.key"
     __test_pcsd_public_key_path: "{{ __ha_cluster_work_dir.path }}/pcsd.crt"

--- a/tests/tests_cluster_basic_new_psks.yml
+++ b/tests/tests_cluster_basic_new_psks.yml
@@ -25,6 +25,7 @@
             prefix: lsr_ha_cluster_
           register: __ha_cluster_work_dir
           delegate_to: localhost
+          run_once: true
 
         - name: Set up test environment
           include_role:
@@ -181,3 +182,5 @@
           file:
             path: "{{ __ha_cluster_work_dir.path }}"
             state: absent
+          delegate_to: localhost
+          run_once: true

--- a/tests/tests_cluster_basic_new_psks.yml
+++ b/tests/tests_cluster_basic_new_psks.yml
@@ -11,13 +11,20 @@
     # generate a new TLS certificate - key pair for pcsd, even if there already
     #   is one
     ha_cluster_regenerate_keys: true
-    ha_cluster_corosync_key_src: "{{ playbook_dir }}/tmp/corosync-authkey"
+    ha_cluster_corosync_key_src: "{{ __ha_cluster_work_dir.path }}/corosync-authkey"
     __test_pacemaker_key_content: key content to be replaced
-    __test_pcsd_private_key_path: "{{ playbook_dir }}/tmp/pcsd.key"
-    __test_pcsd_public_key_path: "{{ playbook_dir }}/tmp/pcsd.crt"
+    __test_pcsd_private_key_path: "{{ __ha_cluster_work_dir.path }}/pcsd.key"
+    __test_pcsd_public_key_path: "{{ __ha_cluster_work_dir.path }}/pcsd.crt"
 
   tasks:
     - block:
+        - name: Create temp directory for secrets
+          tempfile:
+            state: directory
+            prefix: lsr_ha_cluster_
+          register: __ha_cluster_work_dir
+          delegate_to: localhost
+
         - name: Set up test environment
           include_role:
             name: linux-system-roles.ha_cluster
@@ -51,23 +58,21 @@
             state: absent
           when: __test_fence_virt_supported
 
-        - name: Ensure pcsd TLS certificate and key exist
-          block:
-            - name: Distribute pcsd TLS private key
-              copy:
-                src: "{{ __test_pcsd_private_key_path }}"
-                dest: /var/lib/pcsd/pcsd.key
-                owner: root
-                group: root
-                mode: 0600
+        - name: Distribute pcsd TLS private key
+          copy:
+            src: "{{ __test_pcsd_private_key_path }}"
+            dest: /var/lib/pcsd/pcsd.key
+            owner: root
+            group: root
+            mode: 0600
 
-            - name: Distribute pcsd TLS certificate
-              copy:
-                src: "{{ __test_pcsd_public_key_path }}"
-                dest: /var/lib/pcsd/pcsd.crt
-                owner: root
-                group: root
-                mode: 0600
+        - name: Distribute pcsd TLS certificate
+          copy:
+            src: "{{ __test_pcsd_public_key_path }}"
+            dest: /var/lib/pcsd/pcsd.crt
+            owner: root
+            group: root
+            mode: 0600
 
         - name: Get corosync key hash
           stat:
@@ -169,3 +174,9 @@
           include_tasks: tasks/assert_cluster_running.yml
 
       tags: tests::verify
+
+      always:
+        - name: Clean up work directory
+          file:
+            path: "{{ __ha_cluster_work_dir.path }}"
+            state: absent


### PR DESCRIPTION
The tests were writing generated secrets to the directory tests/tmp
which is shared by all tests when running tests in parallel.
Instead, create a real temporary directory for these secrets for the
tests that use generated secrets.
