### PR TITLE
Version 1.7.5 - CHANGELOG.md [citest skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,27 @@
 Changelog
 =========
 
+[1.7.5] - 2022-09-19
+--------------------
+
+### New Features
+
+- none
+
+### Bug Fixes
+
+- only install and setup fence-virt on x86_64 hosts (#64)
+
+fence-virt is not available for any architecture other than x86_64
+
+### Other Changes
+
+- replace yes, no, default with true, false, d
+
+Use `true`, `false`, and `d` instead of `yes`, `no`, and `default`
+
+- readme: update SBD example (#61)
+
 [1.7.4] - 2022-07-19
 --------------------
 


### PR DESCRIPTION
[1.7.5] - 2022-09-19
--------------------

### New Features

- none

### Bug Fixes

- only install and setup fence-virt on x86_64 hosts (#64)

fence-virt is not available for any architecture other than x86_64

### Other Changes

- replace yes, no, default with true, false, d

Use `true`, `false`, and `d` instead of `yes`, `no`, and `default`

- readme: update SBD example (#61)

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
