### PR TITLE
Use the certificate role to create the cert and the key

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ An Ansible role for managing High Availability Clustering.
 The role requires the `firewall` role and the `selinux` role from the
 `fedora.linux_system_roles` collection, if `ha_cluster_manage_firewall`
 and `ha_cluster_manage_selinux` is set to true, respectively.
-(Please see also [`ha_cluster_manage_firewall`](#ha_cluster_manage_firewall)
- and [`ha_cluster_manage_selinux`](#ha_cluster_manage_selinux))
+Please see also [`ha_cluster_manage_firewall`](#ha_cluster_manage_firewall)
+ and [`ha_cluster_manage_selinux`](#ha_cluster_manage_selinux).
 
 If the `ha_cluster` is a role from the `fedora.linux_system_roles`
 collection or from the Fedora RPM package, the requirement is already
@@ -195,6 +195,32 @@ https://docs.ansible.com/ansible/latest/user_guide/vault.html for details.
 If these variables are set, `ha_cluster_regenerate_keys` is ignored for this
 certificate - key pair.
 
+#### `ha_cluster_pcsd_certificates`
+
+If there is no pcsd private key and certificate, there are two ways to create them.
+
+One way is by setting `ha_cluster_pcsd_certificates` variable.
+Another way is by setting none of
+[`ha_cluster_pcsd_public_key_src` and `ha_cluster_pcsd_private_key_src`](#ha_cluster_pcsd_public_key_src-ha_cluster_pcsd_private_key_src) and `ha_cluster_pcsd_certificates`.
+
+If `ha_cluster_pcsd_certificates` is provided, the `certificate` role is internally
+used and it creates the private key and certificate for pcsd as defined.
+If none of the variables are provided, the `ha_cluster` role will create pcsd
+certificates via pcsd itself. 
+
+The value of `ha_cluster_pcsd_certificates` is set to the variable `certificate_requests`
+in the `certificate` role.
+For more information, see the `certificate_requests` section in the `certificate`
+role documentation.
+
+The default value is `[]`.
+
+Note: when you set this variable, you must not set `ha_cluster_pcsd_public_key_src`
+and `ha_cluster_pcsd_private_key_src` variables.
+
+If this variable is set, `ha_cluster_regenerate_keys` is ignored for this
+certificate - key pair.
+
 #### `ha_cluster_regenerate_keys`
 
 boolean, default: `false`
@@ -207,6 +233,7 @@ See also:
 [`ha_cluster_fence_virt_key_src`](#ha_cluster_fence_virt_key_src),
 [`ha_cluster_pcsd_public_key_src`](#ha_cluster_pcsd_public_key_src-ha_cluster_pcsd_private_key_src),
 [`ha_cluster_pcsd_private_key_src`](#ha_cluster_pcsd_public_key_src-ha_cluster_pcsd_private_key_src)
+[`ha_cluster_pcsd_certificates`](#ha_cluster_pcsd_certificates)
 
 #### `ha_cluster_pcs_permission_list`
 
@@ -1047,6 +1074,22 @@ to `true` in your playbooks using the `ha_cluster` role.
     ha_cluster_manage_firewall: true
     ha_cluster_manage_selinux: true
 
+  roles:
+    - linux-system-roles.ha_cluster
+```
+
+### Creating pcsd certificate and private key files using the `certificate` role
+
+This example creates self-signed pcsd certificate and private key files
+in /var/lib/pcsd with the file name FILENAME.crt and FILENAME.key, respectively.
+
+```yaml
+- hosts: node1 node2
+  vars:
+    ha_cluster_pcsd_certificates:
+      - name: FILENAME
+        common_name: "{{ ansible_hostname }}"
+        ca: self-sign
   roles:
     - linux-system-roles.ha_cluster
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,6 +21,7 @@ ha_cluster_pacemaker_key_src: null
 ha_cluster_fence_virt_key_src: null
 ha_cluster_pcsd_public_key_src: null
 ha_cluster_pcsd_private_key_src: null
+ha_cluster_pcsd_certificates: []
 
 ha_cluster_cluster_name: my-cluster
 

--- a/examples/create-pcsd-cert.yml
+++ b/examples/create-pcsd-cert.yml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: MIT
+---
+- name: >-
+    Example ha_cluster role invocation with the pcsd cert
+    and key generation by the certificate role
+  hosts: all
+  vars:
+    ha_cluster_pcsd_certificates:
+      - name: pcsd_cert
+        common_name: "{{ ansible_hostname }}"
+        ca: self-sign
+  roles:
+    - linux-system-roles.ha_cluster

--- a/tasks/check-and-prepare-role-variables.yml
+++ b/tasks/check-and-prepare-role-variables.yml
@@ -87,3 +87,17 @@
     - ha_cluster_quorum.options | d([])
       | selectattr('name', 'match', '^auto_tie_breaker$')
       | map(attribute='value') | select('in', ['0', 0]) | list | length > 0
+
+- name: >-
+    Fail if ha_cluster_pcsd_public_key_src and ha_cluster_pcsd_private_key_src
+    are set along with ha_cluster_pcsd_certificates
+  fail:
+    msg: >-
+      Cannot set ha_cluster_pcsd_public_key_src and
+      ha_cluster_pcsd_private_key_src along with ha_cluster_pcsd_certificates.
+      Remove ha_cluster_pcsd_public_key_src and ha_cluster_pcsd_private_key_src
+      or ha_cluster_pcsd_certificates.
+  when:
+    - ha_cluster_pcsd_public_key_src is not none
+    - ha_cluster_pcsd_private_key_src is not none
+    - ha_cluster_pcsd_certificates | d([])

--- a/tasks/pcs-configure-pcs-pcsd.yml
+++ b/tasks/pcs-configure-pcs-pcsd.yml
@@ -19,6 +19,40 @@
   when:
     - ha_cluster_regenerate_keys
 
+- name: Create pcsd certificate and private_key files
+  when: ha_cluster_pcsd_certificates | length > 0
+  block:
+    - name: Get the stat of /var/lib/pcsd
+      stat:
+        path: /var/lib/pcsd
+      register: __pcsd_stat
+
+    - name: Allow certmonger to write into pcsd's certificate directory
+      file:
+        path: /var/lib/pcsd
+        state: directory
+        setype: cert_t
+        mode: "{{ __pcsd_stat.stat.mode }}"
+
+    - name: >-
+       Ensure the name of ha_cluster_pcsd_certificates is /var/lib/pcsd/pcsd;
+       Create certificates using the certificate role
+      include_role:
+        name: fedora.linux_system_roles.certificate
+      vars:
+        certificate_requests: |
+          {% for _cert in ha_cluster_pcsd_certificates %}
+          {%   set _ = _cert.__setitem__('name', '/var/lib/pcsd/pcsd') %}
+          {% endfor %}
+          {{ ha_cluster_pcsd_certificates }}
+  always:
+    - name: Set pcsd's certificate directory back to cluster_var_lib_t
+      file:
+        path: /var/lib/pcsd
+        state: directory
+        setype: cluster_var_lib_t
+        mode: "{{ __pcsd_stat.stat.mode }}"
+
 - name: Distribute pcsd TLS certificate and key
   block:
     - name: Distribute pcsd TLS private key
@@ -36,6 +70,7 @@
         group: root
         mode: 0600
   when:
+    - ha_cluster_pcsd_certificates | length == 0
     - ha_cluster_pcsd_public_key_src is string
     - ha_cluster_pcsd_public_key_src | length > 0
     - ha_cluster_pcsd_private_key_src is string

--- a/tests/tests_cluster_basic_custom_pcsd_tls_cert_role.yml
+++ b/tests/tests_cluster_basic_custom_pcsd_tls_cert_role.yml
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: MIT
+---
+- name: >-
+    Minimal cluster configuration, custom pcsd TLS certificate -
+    using the certificate role
+  hosts: all
+  vars_files: vars/main.yml
+  vars:
+    ha_cluster_cluster_name: test-cluster
+    __cert_name: pcsd_cert
+
+  tasks:
+    - block:
+        - name: Set up test environment
+          include_role:
+            name: linux-system-roles.ha_cluster
+            tasks_from: test_setup.yml
+
+        - name: Run HA Cluster role
+          include_role:
+            name: linux-system-roles.ha_cluster
+            public: true
+          vars:
+            ha_cluster_pcsd_certificates:
+              - name: "{{ __cert_name }}"
+                common_name: "{{ ansible_hostname }}"
+                ca: self-sign
+
+        - name: Stat pcsd TLS certificate
+          stat:
+            path: /var/lib/pcsd/pcsd.crt
+            checksum_algorithm: sha1
+          register: stat_pcsd_cert
+
+        - name: Stat pcsd TLS key
+          stat:
+            path: /var/lib/pcsd/pcsd.key
+            checksum_algorithm: sha1
+          register: stat_pcsd_key
+
+        - name: Check pre-shared keys and TLS certificates are present
+          assert:
+            that:
+              - stat_pcsd_cert.stat.exists
+              - stat_pcsd_key.stat.exists
+
+        - name: Check firewall and selinux state
+          include_tasks: tasks/check_firewall_selinux.yml
+
+      tags: tests::verify


### PR DESCRIPTION
- Introduce a variable ha_cluster_pcsd_certificates to set the certificate_requests.
- Add a test test script tests/tests_cluster_basic_custom_pcsd_tls_cert_role.yml

I borrowed the mssql README in https://github.com/linux-system-roles/mssql/pull/125 written by @spetrosi. Thanks, Sergei!

@spetrosi, @tomjelinek, this is another piece of the effort to use other roles in the ha_cluster role. If you could review it, I'd greatly appreciate it.