### PR TITLE
long heading causes problems with md to adoc conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1082,7 +1082,7 @@ to `true` in your playbooks using the `ha_cluster` role.
     - linux-system-roles.ha_cluster
 ```
 
-### Creating pcsd certificate and private key files using the `certificate` role
+### Creating pcsd TLS cert and key files using the `certificate` role
 
 This example creates self-signed pcsd certificate and private key files
 in /var/lib/pcsd with the file name FILENAME.crt and FILENAME.key, respectively.


### PR DESCRIPTION
The long heading causes problems with md to adoc conversion.  Shorten
the length by using abbreviations.
