### PR TITLE
Version 1.8.1 - CHANGELOG.md [citest skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,24 @@
 Changelog
 =========
 
+[1.8.1] - 2022-11-14
+--------------------
+
+### New Features
+
+- none
+
+### Bug Fixes
+
+- none
+
+### Other Changes
+
+- long heading causes problems with md to adoc conversion
+
+The long heading causes problems with md to adoc conversion.  Shorten
+the length by using abbreviations.
+
 [1.8.0] - 2022-11-01
 --------------------
 


### PR DESCRIPTION
[1.8.1] - 2022-11-14
--------------------

### New Features

- none

### Bug Fixes

- none

### Other Changes

- long heading causes problems with md to adoc conversion

The long heading causes problems with md to adoc conversion.  Shorten
the length by using abbreviations.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
