### PR TITLE
Add possibility to load SBD watchdog kernel modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1033,9 +1033,9 @@ all:
 #### SBD watchdog and devices
 When using SBD, you may optionally configure watchdog and SBD devices for each
 node in inventory. Even though all SBD devices must be shared to and accessible
-from all nodes, each node may use different names for the devices. Watchdog may
-be different for each node as well. See also [SBD
-variables](#ha_cluster_sbd_enabled).
+from all nodes, each node may use different names for the devices. The loaded
+watchdog modules and used devices may also be different for each node. See also
+[SBD variables](#ha_cluster_sbd_enabled).
 
 Example inventory with targets `node1` and `node2`:
 ```yaml
@@ -1043,18 +1043,30 @@ all:
   hosts:
     node1:
       ha_cluster:
+        sbd_watchdog_modules:
+          - softdog
+          - iTCO_wdt
         sbd_watchdog: /dev/watchdog2
         sbd_devices:
           - /dev/vdx
           - /dev/vdy
     node2:
       ha_cluster:
+        sbd_watchdog_modules:
+          - softdog
+        sbd_watchdog_modules_blocklist:
+          - iTCO_wdt
         sbd_watchdog: /dev/watchdog1
         sbd_devices:
           - /dev/vdw
           - /dev/vdz
 ```
 
+* `sbd_watchdog_modules` (optional) - Watchdog kernel modules to be loaded
+  (creates `/dev/watchdog*` devices). Defaults to empty list if not set.
+* `sbd_watchdog_modules_blocklist` (optional) - Watchdog kernel modules to be
+  unloaded and blocked. Defaults to empty list if not set.
+  `/dev/watchdog` if not set.
 * `sbd_watchdog` (optional) - Watchdog device to be used by SBD. Defaults to
   `/dev/watchdog` if not set.
 * `sbd_devices` (optional) - Devices to use for exchanging SBD messages and for

--- a/meta/collection-requirements.yml
+++ b/meta/collection-requirements.yml
@@ -1,3 +1,4 @@
 # SPDX-License-Identifier: MIT
 collections:
+  - community.general
   - fedora.linux_system_roles

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -61,6 +61,9 @@
       when:
         - ansible_architecture == "x86_64"
 
+    - name: Configure SBD watchdog
+      include_tasks: sbd_watchdog.yml
+
     - name: Configure SBD
       include_tasks: sbd.yml
 

--- a/tasks/sbd_watchdog.yml
+++ b/tasks/sbd_watchdog.yml
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Configure SBD watchdog
+  block:
+    - name: SBD - Configure and unload watchdog kernel modules from blocklist
+      block:
+        - name: "SBD - Configure watchdog kernel module blocklist"
+          ansible.builtin.lineinfile:
+            path: "/etc/modprobe.d/{{ item }}.conf"
+            create: yes
+            mode: 0644
+            regexp: "^(options|blacklist) {{ item }}"
+            line: "blacklist {{ item }}"
+            state: present
+          loop: "{{ ha_cluster.sbd_watchdog_modules_blocklist | d([]) }}"
+          register: __ha_cluster_sbd_watchdog_modules_blocklist_config
+
+        - name: "SBD - Unload watchdog kernel modules from blocklist"
+          community.general.modprobe:
+            name: "{{ item }}"
+            state: absent
+          loop: "{{ ha_cluster.sbd_watchdog_modules_blocklist | d([]) }}"
+          register: __ha_cluster_sbd_watchdog_blocklist_unload_output
+
+    - name: SBD - Configure and load watchdog kernel module
+      block:
+        - name: "SBD - Configure watchdog kernel modules"
+          ansible.builtin.lineinfile:
+            path: "/etc/modules-load.d/{{ item }}.conf"
+            create: yes
+            mode: 0644
+            regexp: "^{{ item }}"
+            line: "{{ item }}"
+            state: present
+          loop: "{{ ha_cluster.sbd_watchdog_modules | d([]) }}"
+          register: __ha_cluster_sbd_watchdog_modules_load_config
+
+        - name: "SBD - Load watchdog kernel modules"
+          community.general.modprobe:
+            name: "{{ item }}"
+            state: present
+          loop: "{{ ha_cluster.sbd_watchdog_modules | d([]) }}"
+          register: __ha_cluster_sbd_watchdog_modules_load_output
+
+  when:
+    - ha_cluster_sbd_enabled

--- a/tests/tests_sbd_all_options.yml
+++ b/tests/tests_sbd_all_options.yml
@@ -31,6 +31,10 @@
         - name: Set SBD devices and watchdogs
           set_fact:
             ha_cluster:
+              sbd_watchdog_modules:
+                - softdog
+              sbd_watchdog_modules_blocklist:
+                - iTCO_wdt
               sbd_watchdog: /dev/null
               sbd_devices:
                 - "{{ __test_sbd_mount.stdout }}"
@@ -39,6 +43,74 @@
           include_role:
             name: linux-system-roles.ha_cluster
             public: true
+
+
+        - name: Slurp generated SBD watchdog blocklist file
+          slurp:
+            src: /etc/modprobe.d/iTCO_wdt.conf
+          register: __test_sbd_watchdog_blocklist_file
+
+        - name: Decode SBD watchdog blocklist file
+          set_fact:
+            __test_sbd_watchdog_blocklist_file_lines: "{{
+                (__test_sbd_watchdog_blocklist_file.content |
+                b64decode).splitlines()
+              }}"
+
+        - name: Print SBD watchdog blocklist file lines
+          debug:
+            var: __test_sbd_watchdog_blocklist_file_lines
+
+        - name: Check SBD watchdog blocklist file
+          assert:
+            that:
+              - "__blockstr in __test_sbd_watchdog_blocklist_file_lines"
+            vars:
+              __blockstr: blacklist iTCO_wdt
+
+
+        - name: Slurp generated SBD watchdog modprobe file
+          slurp:
+            src: /etc/modules-load.d/softdog.conf
+          register: __test_sbd_watchdog_modprobe_file
+
+        - name: Decode SBD watchdog modprobe file
+          set_fact:
+            __test_sbd_watchdog_modprobe_file_lines: "{{
+                (__test_sbd_watchdog_modprobe_file.content |
+                b64decode).splitlines()
+              }}"
+
+        - name: Print SBD watchdog modprobe file lines
+          debug:
+            var: __test_sbd_watchdog_modprobe_file_lines
+
+        - name: Check SBD watchdog modprobe file
+          assert:
+            that:
+              - "__modulestr in __test_sbd_watchdog_modprobe_file_lines"
+            vars:
+              __modulestr: softdog
+
+
+        - name: Run lsmod for SBD watchdog module
+          command: lsmod
+          register: __test_sbd_watchdog_sbd_lsmod
+
+        - name: Print lsmod
+          debug:
+            var: __test_sbd_watchdog_sbd_lsmod
+
+        - name: Check lsmod output for absence of SBD watchdog module blocklist
+          assert:
+            that:
+              - "'iTCO_wdt' not in __test_sbd_watchdog_sbd_lsmod.stdout"
+
+        - name: Check lsmod output for SBD watchdog module
+          assert:
+            that:
+              - "'softdog' in __test_sbd_watchdog_sbd_lsmod.stdout"
+
 
         - name: Slurp SBD config file
           slurp:


### PR DESCRIPTION
SBD needs a watchdog device to work. The watchdog device is created by loading one or more watchdog kernel modules. The modules can be configured on a per node basis. Blocking certain modules from being loaded is also often a use case (e.g due to hardware specifics).