### PR TITLE
Allow enabled SBD on disabled cluster

### DIFF
--- a/tasks/cluster-enable-disable.yml
+++ b/tasks/cluster-enable-disable.yml
@@ -20,11 +20,8 @@
   service:
     name: sbd
     enabled: "{{ ha_cluster_sbd_enabled }}"
-    # Null (i.e. nochange) is currently not supported: Either all nodes are
-    # configured to start the cluster on boot or not to start the cluster on
-    # boot. Null (nochange) could lead to situations where part of cluster
-    # nodes are configured to start the cluster on boot while other nodes in
-    # the same cluster are not.
+    # Enabling SBD doesn't depend on 'ha_cluster_start_on_boot' variable as SBD
+    # is started automatically by pacemaker.
   when:
     - '"sbd.service" in ansible_facts.services'
   register: __ha_cluster_sbd_service_enable_disable

--- a/tasks/cluster-enable-disable.yml
+++ b/tasks/cluster-enable-disable.yml
@@ -19,7 +19,7 @@
 - name: Enable or disable SBD
   service:
     name: sbd
-    enabled: "{{ ha_cluster_sbd_enabled and ha_cluster_start_on_boot }}"
+    enabled: "{{ ha_cluster_sbd_enabled }}"
     # Null (i.e. nochange) is currently not supported: Either all nodes are
     # configured to start the cluster on boot or not to start the cluster on
     # boot. Null (nochange) could lead to situations where part of cluster

--- a/tests/tests_sbd_defaults_disabled.yml
+++ b/tests/tests_sbd_defaults_disabled.yml
@@ -15,10 +15,18 @@
             name: linux-system-roles.ha_cluster
             tasks_from: test_setup.yml
 
+        - name: Set up test environment for SBD
+          include_role:
+            name: linux-system-roles.ha_cluster
+            tasks_from: test_setup_sbd.yml
+
         - name: Run HA Cluster role
           include_role:
             name: linux-system-roles.ha_cluster
             public: true
+
+        # Checking SBD config file content and Auto Tie Breaker configuration
+        # is done in tests_sbd_defaults.yml
 
         - name: Get services status
           service_facts:
@@ -30,7 +38,15 @@
               - ansible_facts.services["pacemaker.service"].status == "disabled"
               - ansible_facts.services["sbd.service"].status == "enabled"
 
+        - name: Check cluster status
+          include_tasks: tasks/assert_cluster_running.yml
+
         - name: Check firewall and selinux state
           include_tasks: tasks/check_firewall_selinux.yml
 
+      always:
+        - name: Clean up test environment for SBD
+          include_role:
+            name: linux-system-roles.ha_cluster
+            tasks_from: test_cleanup_sbd.yml
       tags: tests::verify

--- a/tests/tests_sbd_defaults_disabled.yml
+++ b/tests/tests_sbd_defaults_disabled.yml
@@ -28,7 +28,7 @@
             that:
               - ansible_facts.services["corosync.service"].status == "disabled"
               - ansible_facts.services["pacemaker.service"].status == "disabled"
-              - ansible_facts.services["sbd.service"].status == "disabled"
+              - ansible_facts.services["sbd.service"].status == "enabled"
 
         - name: Check firewall and selinux state
           include_tasks: tasks/check_firewall_selinux.yml


### PR DESCRIPTION
follow up PR from #78 with no `/` in branch name.

Currently the `sbd.service`will not be enabled if the cluster autostart is disabled. This is not intended behavior as is will effectively break the feature.
We can simply remove the condition to depend on `ha_cluster_start_on_boot` as on a RHEL8 system the `sbd.service` has a dependencies (`Before/After/PartOf/RequiredBy`) to cluster related services which make sure it is only ever started by the cluster (a manual start is not possible).

```
# /usr/lib/systemd/system/sbd.service
[Unit]
[...]
Before=pacemaker.service
Before=dlm.service
After=systemd-modules-load.service iscsi.service
PartOf=corosync.service
[...]

[Install]
RequiredBy=corosync.service
RequiredBy=pacemaker.service
RequiredBy=dlm.service
```