### PR TITLE
Add possibility to load SBD watchdog kernel modules

### DIFF
--- a/examples/sbd.yml
+++ b/examples/sbd.yml
@@ -2,6 +2,7 @@
 ---
 - name: Example ha_cluster role invocation - cluster with SBD
   hosts: node1 node2
+  # do not forget to also set variables via inventory or host_vars.
   vars:
     ha_cluster_manage_firewall: true
     ha_cluster_manage_selinux: true
@@ -16,12 +17,24 @@
       - name: timeout-action
         value: 'flush,reboot'
       - name: watchdog-timeout
-        value: 5
-    #  if you need to set stonith-watchdog-timeout property as well:
+        value: 30
+    # Best practice for setting SBD timeouts:
+    # watchdog-timeout * 2 = msgwait-timeout (set automatically)
+    # msgwait-timeout * 1.2 = stonith-timeout
     ha_cluster_cluster_properties:
       - attrs:
-          - name: stonith-watchdog-timeout
-            value: 10
+          - name: stonith-timeout
+            value: 72
+    ha_cluster_resource_primitives:
+      - id: fence_sbd
+        agent: 'stonith:fence_sbd'
+        instance_attrs:
+          - attrs:
+              # taken from host_vars
+              - name: devices
+                value: "{{ ha_cluster.sbd_devices | join(',') }}"
+              - name: pcmk_delay_base
+                value: 30
 
   roles:
     - linux-system-roles.ha_cluster

--- a/meta/collection-requirements.yml
+++ b/meta/collection-requirements.yml
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: MIT
 ---
 collections:
+  - community.general
   - fedora.linux_system_roles

--- a/tasks/sbd.yml
+++ b/tasks/sbd.yml
@@ -3,7 +3,45 @@
 - name: Manage SBD
   when: ha_cluster_sbd_enabled
   block:
-    - name: Manage SBD
+    - name: Configure SBD watchdog
+      block:
+        - name: Configure and unload watchdog kernel modules from blocklist
+          block:
+            - name: Configure watchdog kernel module blocklist
+              lineinfile:
+                path: "/etc/modprobe.d/{{ item }}.conf"
+                create: true
+                mode: 0644
+                regexp: "^(options|blacklist) {{ item }}"
+                line: "blacklist {{ item }}"
+                state: present
+              loop: "{{ ha_cluster.sbd_watchdog_modules_blocklist | d([]) }}"
+
+            - name: Unload watchdog kernel modules from blocklist
+              modprobe:
+                name: "{{ item }}"
+                state: absent
+              loop: "{{ ha_cluster.sbd_watchdog_modules_blocklist | d([]) }}"
+
+        - name: Configure and load watchdog kernel module
+          block:
+            - name: Configure watchdog kernel modules
+              lineinfile:
+                path: "/etc/modules-load.d/{{ item }}.conf"
+                create: true
+                mode: 0644
+                regexp: "^{{ item }}"
+                line: "{{ item }}"
+                state: present
+              loop: "{{ ha_cluster.sbd_watchdog_modules | d([]) }}"
+
+            - name: Load watchdog kernel modules
+              modprobe:
+                name: "{{ item }}"
+                state: present
+              loop: "{{ ha_cluster.sbd_watchdog_modules | d([]) }}"
+
+    - name: Manage SBD devices
       # Ideally, the block as a whole should run one node at a time. This does
       # not seem to be possible with Ansible yet. Instead, we at least make the
       # block's tasks run one by one. This way, we avoid possible issues caused

--- a/tasks/test_setup_sbd.yml
+++ b/tasks/test_setup_sbd.yml
@@ -9,6 +9,9 @@
 - name: Load softdog module for SBD to have at least one watchdog
   command: modprobe softdog
   changed_when: true
+  # do not load if sbd tests are run (loads module instead)
+  when:
+  - not (__test_disable_modprobe | d(false))
 
 - name: Create backing files for SBD devices
   tempfile:

--- a/tests/tests_sbd_all_options.yml
+++ b/tests/tests_sbd_all_options.yml
@@ -29,10 +29,16 @@
           include_role:
             name: linux-system-roles.ha_cluster
             tasks_from: test_setup_sbd.yml
+          vars:
+            __test_disable_modprobe: true
 
         - name: Set SBD devices and watchdogs
           set_fact:
             ha_cluster:
+              sbd_watchdog_modules:
+                - softdog
+              sbd_watchdog_modules_blocklist:
+                - iTCO_wdt
               sbd_watchdog: /dev/null
               sbd_devices:
                 - "{{ __test_sbd_mount.stdout }}"
@@ -41,6 +47,71 @@
           include_role:
             name: linux-system-roles.ha_cluster
             public: true
+
+        - name: Slurp generated SBD watchdog blocklist file
+          slurp:
+            src: /etc/modprobe.d/iTCO_wdt.conf
+          register: __test_sbd_watchdog_blocklist_file
+
+        - name: Decode SBD watchdog blocklist file
+          set_fact:
+            __test_sbd_watchdog_blocklist_file_lines: "{{
+                (__test_sbd_watchdog_blocklist_file.content |
+                b64decode).splitlines()
+              }}"
+
+        - name: Print SBD watchdog blocklist file lines
+          debug:
+            var: __test_sbd_watchdog_blocklist_file_lines
+
+        - name: Check SBD watchdog blocklist file
+          assert:
+            that:
+              - __blockstr in __test_sbd_watchdog_blocklist_file_lines
+          vars:
+            __blockstr: blacklist iTCO_wdt
+
+        - name: Slurp generated SBD watchdog modprobe file
+          slurp:
+            src: /etc/modules-load.d/softdog.conf
+          register: __test_sbd_watchdog_modprobe_file
+
+        - name: Decode SBD watchdog modprobe file
+          set_fact:
+            __test_sbd_watchdog_modprobe_file_lines: "{{
+                (__test_sbd_watchdog_modprobe_file.content |
+                b64decode).splitlines()
+              }}"
+
+        - name: Print SBD watchdog modprobe file lines
+          debug:
+            var: __test_sbd_watchdog_modprobe_file_lines
+
+        - name: Check SBD watchdog modprobe file
+          assert:
+            that:
+              - __modulestr in __test_sbd_watchdog_modprobe_file_lines
+          vars:
+            __modulestr: softdog
+
+        - name: Run lsmod for SBD watchdog module
+          command: lsmod
+          changed_when: false
+          register: __test_sbd_watchdog_sbd_lsmod
+
+        - name: Print lsmod
+          debug:
+            var: __test_sbd_watchdog_sbd_lsmod
+
+        - name: Check lsmod output for absence of SBD watchdog module blocklist
+          assert:
+            that:
+              - "'iTCO_wdt' not in __test_sbd_watchdog_sbd_lsmod.stdout"
+
+        - name: Check lsmod output for SBD watchdog module
+          assert:
+            that:
+              - "'softdog' in __test_sbd_watchdog_sbd_lsmod.stdout"
 
         - name: Slurp SBD config file
           slurp:


### PR DESCRIPTION
follow up PR from #79 with no `/` in branch name.

SBD needs a watchdog device to work. The watchdog device is created by loading one or more watchdog kernel modules. The modules can be configured on a per node basis. Blocking certain modules from being loaded is also often a use case (e.g due to hardware specifics).