### PR TITLE
tests: add qnetd cleanup

### DIFF
--- a/tasks/test_cleanup_qnetd.yml
+++ b/tasks/test_cleanup_qnetd.yml
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: MIT
+# This task configures test systems for testing in the CI environment.
+# Only use this task for testing.
+# This task file resides in `tasks/` so that it can be used from other roles
+# with `include_role` with `tasks_from: filename` directly without the need to
+# provide a relative path. Providing relative path is problematic with
+# collections.
+---
+- name: Make sure qnetd is not installed
+  package:
+    name:
+      - corosync-qnetd
+    state: absent
+
+- name: Make sure qnetd config files are not present
+  file:
+    path: /etc/corosync/qnetd
+    state: absent

--- a/tests/tests_qdevice_minimal.yml
+++ b/tests/tests_qdevice_minimal.yml
@@ -13,7 +13,12 @@
             name: linux-system-roles.ha_cluster
             tasks_from: test_setup.yml
 
-        - name: Set up test environment for qnetd / qdevice
+        - name: Clean up test environment for qnetd
+          include_role:
+            name: linux-system-roles.ha_cluster
+            tasks_from: test_cleanup_qnetd.yml
+
+        - name: Set up test environment for qnetd
           include_role:
             name: linux-system-roles.ha_cluster
             tasks_from: test_setup_qnetd.yml
@@ -99,4 +104,9 @@
         - name: Check qdevice status
           include_tasks: tasks/assert_qdevice_in_cluster.yml
 
+      always:
+        - name: Clean up test environment for qnetd
+          include_role:
+            name: linux-system-roles.ha_cluster
+            tasks_from: test_cleanup_qnetd.yml
       tags: tests::verify

--- a/tests/tests_qnetd.yml
+++ b/tests/tests_qnetd.yml
@@ -14,6 +14,11 @@
             name: linux-system-roles.ha_cluster
             tasks_from: test_setup.yml
 
+        - name: Clean up test environment for qnetd
+          include_role:
+            name: linux-system-roles.ha_cluster
+            tasks_from: test_cleanup_qnetd.yml
+
         - name: Run HA Cluster role
           include_role:
             name: linux-system-roles.ha_cluster

--- a/tests/tests_qnetd_disabled.yml
+++ b/tests/tests_qnetd_disabled.yml
@@ -15,6 +15,11 @@
             name: linux-system-roles.ha_cluster
             tasks_from: test_setup.yml
 
+        - name: Clean up test environment for qnetd / qdevice
+          include_role:
+            name: linux-system-roles.ha_cluster
+            tasks_from: test_cleanup_qnetd.yml
+
         - name: Run HA Cluster role
           include_role:
             name: linux-system-roles.ha_cluster


### PR DESCRIPTION
Ensure that qnetd package is not installed and there are no qnetd config files present to verify that the role really installs and creates those. This also sets test environment to a clearly defined and correct state, which is needed in case tests are not isolated.