### PR TITLE
command warn is not supported in ansible-core 2.14

### DIFF
--- a/tasks/enable-repositories/CentOS.yml
+++ b/tasks/enable-repositories/CentOS.yml
@@ -3,8 +3,6 @@
 - name: List active CentOS repositories
   command:
     cmd: dnf repolist
-    # See the comment bellow.
-    warn: false
   register: __ha_cluster_repolist
   changed_when: false
   check_mode: false
@@ -12,17 +10,5 @@
 - name: Enable CentOS repositories
   command:
     cmd: dnf config-manager --set-enabled {{ item.id | quote }}
-    # Silence a warning which recommends using ansible dnf module instead of
-    # running dnf command.
-    #
-    # yum_repository module documentation states, "If you wish to update an
-    # existing repository definition use ini_file instead."
-    #
-    # ini_file requires a file path and a section name, both of which are
-    # different in various CentOS minor versions.
-    #
-    # Using dnf, similar differences must also be handled. But at least the
-    # approach and __ha_cluster_repos structure is the same as for RHEL.
-    warn: false
   loop: "{{ __ha_cluster_repos }}"
   when: item.name not in __ha_cluster_repolist.stdout

--- a/tasks/enable-repositories/RedHat.yml
+++ b/tasks/enable-repositories/RedHat.yml
@@ -3,7 +3,6 @@
 - name: List active RHEL repositories
   command:
     cmd: dnf repolist
-    warn: false
   register: __ha_cluster_repolist
   changed_when: false
   check_mode: false


### PR DESCRIPTION
If users want to suppress the warning, users will need to configure ansible.cfg.