### PR TITLE
Not request password to be specified when purging cluster

### DIFF
--- a/tasks/check-and-prepare-role-variables.yml
+++ b/tasks/check-and-prepare-role-variables.yml
@@ -7,7 +7,7 @@
         msg: "{{ item }} must be specified"
       when:
         - lookup("vars", item, default="") | string | length < 1
-        - ha_cluster_cluster_present
+        - ha_cluster_cluster_present | bool
       loop:
         - ha_cluster_hacluster_password
       run_once: true

--- a/tasks/check-and-prepare-role-variables.yml
+++ b/tasks/check-and-prepare-role-variables.yml
@@ -5,7 +5,9 @@
     - name: Fail if passwords are not specified
       fail:
         msg: "{{ item }} must be specified"
-      when: lookup("vars", item, default="") | string | length < 1
+      when:
+        - lookup("vars", item, default="") | string | length < 1
+        - ha_cluster_cluster_present
       loop:
         - ha_cluster_hacluster_password
       run_once: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,6 +29,8 @@
       ha_cluster_hacluster_password | string
       | password_hash('sha512', ansible_hostname.replace('-','x')[:16])
     }}"
+  when:
+    - ha_cluster_hacluster_password | string | length > 0
 
 - name: Configure pcs / pcsd
   include_tasks: pcs-configure-pcs-pcsd.yml


### PR DESCRIPTION
When running the role with ha_cluster_cluster_present: false to purge cluster passwords are not required