### PR TITLE
more ansible-lint 6.x fixes

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,3 +1,20 @@
 ---
 skip_list:
   - fqcn-builtins
+exclude_paths:
+  - tests/roles/
+  - .github/
+  - examples/roles/
+kinds:
+  - yaml: "**/meta/collection-requirements.yml"
+  - yaml: "**/tests/collection-requirements.yml"
+  - playbook: "**/tests/tests_*.yml"
+  - playbook: "**/tests/setup-snapshot.yml"
+  - tasks: "**/tests/*.yml"
+  - playbook: "**/tests/playbooks/*.yml"
+  - tasks: "**/tests/tasks/*.yml"
+  - tasks: "**/tests/tasks/*/*.yml"
+  - vars: "**/tests/vars/*.yml"
+  - playbook: "**/examples/*.yml"
+mock_roles:
+  - linux-system-roles.ha_cluster

--- a/examples/sbd.yml
+++ b/examples/sbd.yml
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 ---
-- hosts: node1 node2
+- name: Manage SBD options
+  hosts: node1 node2
   vars:
     ha_cluster_manage_firewall: true
     ha_cluster_manage_selinux: true

--- a/examples/sbd.yml
+++ b/examples/sbd.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 ---
-- name: Manage SBD options
+- name: Example ha_cluster role invocation - cluster with SBD
   hosts: node1 node2
   vars:
     ha_cluster_manage_firewall: true

--- a/tasks/cluster-setup-corosync.yml
+++ b/tasks/cluster-setup-corosync.yml
@@ -5,7 +5,7 @@
     state: file
     suffix: _ha_cluster_corosync_conf
   register: __ha_cluster_tempfile_corosync_conf
-  run_once: true
+  run_once: true  # noqa: run_once[task]
   # We always need to create corosync.conf file to see whether it's the same as
   # what is already present on the cluster nodes. However, we don't want to
   # report it as a change since the only thing which matters is copying the
@@ -20,7 +20,7 @@
   slurp:
     src: "{{ __ha_cluster_tempfile_corosync_conf.path }}"
   register: __ha_cluster_data_corosync_conf
-  run_once: true
+  run_once: true  # noqa: run_once[task]
   when: __ha_cluster_tempfile_corosync_conf.path is defined
 
 - name: Distribute corosync.conf file
@@ -38,7 +38,7 @@
     path: "{{ __ha_cluster_tempfile_corosync_conf.path }}"
     state: absent
   when: __ha_cluster_tempfile_corosync_conf.path is defined
-  run_once: true
+  run_once: true  # noqa: run_once[task]
   # We always need to create corosync.conf file to see whether it's the same as
   # what is already present on the cluster nodes. However, we don't want to
   # report it as a change since the only thing which matters is copying the

--- a/tasks/cluster-start-and-reload.yml
+++ b/tasks/cluster-start-and-reload.yml
@@ -56,7 +56,7 @@
 - name: Reload corosync configuration
   command:
     cmd: corosync-cfgtool -R
-  run_once: true
+  run_once: true  # noqa: run_once[task]
   when: not ansible_check_mode
 
 - name: Start corosync-qdevice
@@ -74,7 +74,7 @@
 - name: Wait for the cluster to fully start and form membership
   command:
     cmd: pcs cluster start --all --wait
-  run_once: true
+  run_once: true  # noqa: run_once[task]
   # There is no point in waiting in check mode as there is nothing to wait for,
   # no daemons are actually starting.
   when: not ansible_check_mode
@@ -97,7 +97,7 @@
     # removed from a cluster after corosync / pacemaker restart. Therefore,
     # crm_node is no help when we want to list such nodes.
   register: __ha_cluster_list_pacemaker_nodes
-  run_once: true
+  run_once: true  # noqa: run_once[task]
   # This cannot be run in the check mode as it requires cluster to be started
   # and its configuration reloaded. Check mode does not start the cluster nor
   # does it reload its configuration, it only shows the cluster would be
@@ -109,7 +109,7 @@
 - name: Purge removed nodes from pacemaker's cache
   command:
     cmd: pcs -- cluster node clear {{ item | quote }}
-  run_once: true
+  run_once: true  # noqa: run_once[task]
   loop: "{{ __ha_cluster_list_pacemaker_nodes.stdout_lines }}"
   # This cannot be run in the check mode as it requires cluster to be started.
   # Check mode does not start the cluster, it only shows the cluster would be

--- a/tasks/create-and-push-cib.yml
+++ b/tasks/create-and-push-cib.yml
@@ -230,7 +230,7 @@
     cmd: >
       cibadmin --verbose --patch
       --xml-file {{ __ha_cluster_tempfile_cib_diff.path | quote }}
-  run_once: true
+  run_once: true  # noqa: run_once[task]
   when: __ha_cluster_cib_diff.rc == 1
 
 - name: Remove CIB tempfiles

--- a/tasks/pcs-auth-pcs-0.10.yml
+++ b/tasks/pcs-auth-pcs-0.10.yml
@@ -22,5 +22,5 @@
         {% endif %}
       {% endif %}
     stdin: "{{ ha_cluster_hacluster_password }}"
-  run_once: true
+  run_once: true  # noqa: run_once[task]
   changed_when: true

--- a/tasks/pcs-cluster-setup-pcs-0.10.yml
+++ b/tasks/pcs-cluster-setup-pcs-0.10.yml
@@ -69,7 +69,7 @@
           auto_tie_breaker=1
         {% endif %}
       {% endif %}
-  run_once: true
+  run_once: true  # noqa: run_once[task]
   # We always need to create corosync.conf file to see whether it's the same as
   # what is already present on the cluster nodes. However, we don't want to
   # report it as a change since the only thing which matters is copying the
@@ -99,7 +99,7 @@
           {{ option.name | quote }}={{ option.value | quote }}
         {% endfor %}
       {% endif %}
-  run_once: true
+  run_once: true  # noqa: run_once[task]
   when:
     - __ha_cluster_qdevice_in_use
   # We always need to create corosync.conf file to see whether it's the same as

--- a/tasks/presharedkey.yml
+++ b/tasks/presharedkey.yml
@@ -10,7 +10,7 @@
 - name: Retrieve from the controller key {{ preshared_key_label }}
   when:
     - preshared_key_src is string and preshared_key_src | length > 1
-  run_once: true
+  run_once: true  # noqa: run_once[task]
   delegate_to: localhost
   block:
     - name: Check if key exists on the controller {{ preshared_key_label }}
@@ -37,7 +37,7 @@
 - name: Generate random key {{ preshared_key_label }}
   when:
     - not (preshared_key_src is string and preshared_key_src | length > 1)
-  run_once: true
+  run_once: true  # noqa: run_once[task]
   # Prevent key contents to be printed to the output
   no_log: true
   block:

--- a/tests/setup-snapshot.yml
+++ b/tests/setup-snapshot.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: all
+- name: Setup snapshot
+  hosts: all
   tasks:
     - name: Set platform/version specific variables
       include_role:
@@ -16,6 +17,5 @@
           +
           ha_cluster_fence_agent_packages
           +
-          ha_cluster_extra_packages
-        }}"
+          ha_cluster_extra_packages }}"
         state: present

--- a/tests/tasks/fixture_psks.yml
+++ b/tests/tasks/fixture_psks.yml
@@ -2,7 +2,7 @@
 ---
 - name: Generate pre-shared keys and certificates on the controller
   delegate_to: localhost
-  run_once: true
+  run_once: true  # noqa: run_once[task]
   vars:
     __test_pcsd_private_key_path: "{{ __ha_cluster_work_dir.path }}/pcsd.key"
     __test_pcsd_public_key_path: "{{ __ha_cluster_work_dir.path }}/pcsd.crt"

--- a/tests/tests_cib_constraints_create.yml
+++ b/tests/tests_cib_constraints_create.yml
@@ -385,7 +385,9 @@
     ha_cluster_manage_selinux: true
 
   tasks:
-    - block:
+    - name: Run tests
+      tags: tests::verify
+      block:
         - name: Set up test environment
           include_role:
             name: linux-system-roles.ha_cluster
@@ -420,25 +422,7 @@
               }}"
 
         # yamllint disable rule:line-length
-        - block:
-            - name: Fetch location constraints configuration from the cluster
-              command:
-                cmd: pcs constraint location --full
-              register: __test_pcs_location_config
-              changed_when: false
-
-            - name: Print real location constraints configuration
-              debug:
-                var: __test_pcs_location_config.stdout_lines
-
-            - name: Print expected location constraints configuration
-              debug:
-                var: __test_expected_lines | select | list
-
-            - name: Check location constraints configuration
-              assert:
-                that:
-                  - __test_pcs_location_config.stdout_lines == __test_expected_lines | select | list
+        - name: Get location constraints
           vars:
             __test_role_promoted: "{%
                 if __test_new_roles_pcs
@@ -540,26 +524,27 @@
               - '    Constraint: location-d3-4 (resource-discovery=always)'
               - '      Rule: score=INFINITY (id:location-d3-4-rule)'
               - '        Expression: rule eq 6 (id:location-d3-4-rule-expr)'
-
-        - block:
-            - name: Fetch colocation constraints configuration from the cluster
+          block:
+            - name: Fetch location constraints configuration from the cluster
               command:
-                cmd: pcs constraint colocation --full
-              register: __test_pcs_colocation_config
+                cmd: pcs constraint location --full
+              register: __test_pcs_location_config
               changed_when: false
 
-            - name: Print real colocation constraints configuration
+            - name: Print real location constraints configuration
               debug:
-                var: __test_pcs_colocation_config.stdout_lines
+                var: __test_pcs_location_config.stdout_lines
 
-            - name: Print expected colocation constraints configuration
+            - name: Print expected location constraints configuration
               debug:
                 var: __test_expected_lines | select | list
 
-            - name: Check colocation constraints configuration
+            - name: Check location constraints configuration
               assert:
                 that:
-                  - __test_pcs_colocation_config.stdout_lines == __test_expected_lines | select | list
+                  - __test_pcs_location_config.stdout_lines == __test_expected_lines | select | list
+
+        - name: Get colocation constraints
           vars:
             __test_expected_lines:
               - 'Colocation Constraints:'
@@ -580,8 +565,40 @@
               - "    set d1 d2 role={{
                   __test_new_roles_pcs | ternary('Promoted', 'Master')
                   }} (id:cc-set_set) set d3 d4 sequential=false (id:cc-set_set-1) setoptions score=20 (id:cc-set)"
+          block:
+            - name: Fetch colocation constraints configuration from the cluster
+              command:
+                cmd: pcs constraint colocation --full
+              register: __test_pcs_colocation_config
+              changed_when: false
 
-        - block:
+            - name: Print real colocation constraints configuration
+              debug:
+                var: __test_pcs_colocation_config.stdout_lines
+
+            - name: Print expected colocation constraints configuration
+              debug:
+                var: __test_expected_lines | select | list
+
+            - name: Check colocation constraints configuration
+              assert:
+                that:
+                  - __test_pcs_colocation_config.stdout_lines == __test_expected_lines | select | list
+
+        - name: Get order constraints
+          vars:
+            __test_expected_lines:
+              - 'Ordering Constraints:'
+              - '  start d1 then start d2 (kind:Mandatory) (id:order-d1-d2-mandatory)'
+              - '  start d2 then start d3 (kind:Mandatory) (id:co-id)'
+              - '  demote d3 then promote d4 (kind:Mandatory) (id:order-d3-d4-mandatory)'
+              - '  start d1 then start d3 (kind:Optional) (non-symmetrical) (Options: require-all=false) (id:order-d1-d3-Optional)'
+              - '  start d1 then start d4 (score:-15) (id:order-d1-d4--15)'
+              - '  demote d2 then stop d4 (score:10) (non-symmetrical) (Options: require-all=false) (id:co-all)'
+              - '  Resource Sets:'
+              - '    set d1 d2 (id:order_set_d1d2_set) (id:order_set_d1d2)'
+              - '    set d1 d2 action=promote (id:co-set_set) set d3 d4 require-all=true sequential=false (id:co-set_set-1) setoptions kind=Serialize symmetrical=false (id:co-set)'
+          block:
             - name: Fetch order constraints configuration from the cluster
               command:
                 cmd: pcs constraint order --full
@@ -600,20 +617,26 @@
               assert:
                 that:
                   - __test_pcs_order_config.stdout_lines == __test_expected_lines | select | list
+
+        - name: Get ticket constraints
           vars:
             __test_expected_lines:
-              - 'Ordering Constraints:'
-              - '  start d1 then start d2 (kind:Mandatory) (id:order-d1-d2-mandatory)'
-              - '  start d2 then start d3 (kind:Mandatory) (id:co-id)'
-              - '  demote d3 then promote d4 (kind:Mandatory) (id:order-d3-d4-mandatory)'
-              - '  start d1 then start d3 (kind:Optional) (non-symmetrical) (Options: require-all=false) (id:order-d1-d3-Optional)'
-              - '  start d1 then start d4 (score:-15) (id:order-d1-d4--15)'
-              - '  demote d2 then stop d4 (score:10) (non-symmetrical) (Options: require-all=false) (id:co-all)'
+              - 'Ticket Constraints:'
+              - '  d1 ticket=ticket1 (id:ticket-ticket1-d1)'
+              - '  d1 ticket=ticket2 (id:ct-id)'
+              - "  {{
+                  __test_new_roles_pcs | ternary('Promoted', 'Master')
+                  }} d2 ticket=ticket1 (id:ticket-ticket1-d2-{{
+                  __test_new_roles_cib | ternary('Promoted', 'Master')
+                  }})"
+              - '  d2 loss-policy=stop ticket=ticket2 (id:ticket-ticket2-d2)'
+              - "  {{
+                  __test_new_roles_pcs | ternary('Unpromoted', 'Slave')
+                  }} d3 loss-policy=demote ticket=ticket3 (id:ct-all)"
               - '  Resource Sets:'
-              - '    set d1 d2 (id:order_set_d1d2_set) (id:order_set_d1d2)'
-              - '    set d1 d2 action=promote (id:co-set_set) set d3 d4 require-all=true sequential=false (id:co-set_set-1) setoptions kind=Serialize symmetrical=false (id:co-set)'
-
-        - block:
+              - '    set d1 (id:ticket_set_d1_set) setoptions ticket=ticket-set1 (id:ticket_set_d1)'
+              - '    set d1 d2 (id:ct-set_set) set d3 d4 require-all=true sequential=false (id:ct-set_set-1) setoptions loss-policy=fence ticket=ticket-set1 (id:ct-set)'
+          block:
             - name: Fetch ticket constraints configuration from the cluster
               command:
                 cmd: pcs constraint ticket --full
@@ -632,27 +655,6 @@
               assert:
                 that:
                   - __test_pcs_ticket_config.stdout_lines == __test_expected_lines | select | list
-          vars:
-            __test_expected_lines:
-              - 'Ticket Constraints:'
-              - '  d1 ticket=ticket1 (id:ticket-ticket1-d1)'
-              - '  d1 ticket=ticket2 (id:ct-id)'
-              - "  {{
-                  __test_new_roles_pcs | ternary('Promoted', 'Master')
-                  }} d2 ticket=ticket1 (id:ticket-ticket1-d2-{{
-                  __test_new_roles_cib | ternary('Promoted', 'Master')
-                  }})"
-              - '  d2 loss-policy=stop ticket=ticket2 (id:ticket-ticket2-d2)'
-              - "  {{
-                  __test_new_roles_pcs | ternary('Unpromoted', 'Slave')
-                  }} d3 loss-policy=demote ticket=ticket3 (id:ct-all)"
-              - '  Resource Sets:'
-              - '    set d1 (id:ticket_set_d1_set) setoptions ticket=ticket-set1 (id:ticket_set_d1)'
-              - '    set d1 d2 (id:ct-set_set) set d3 d4 require-all=true sequential=false (id:ct-set_set-1) setoptions loss-policy=fence ticket=ticket-set1 (id:ct-set)'
 
         - name: Check firewall and selinux state
           include_tasks: tasks/check_firewall_selinux.yml
-
-      # yamllint enable rule:line-length
-
-      tags: tests::verify

--- a/tests/tests_cib_constraints_create.yml
+++ b/tests/tests_cib_constraints_create.yml
@@ -422,7 +422,7 @@
               }}"
 
         # yamllint disable rule:line-length
-        - name: Get location constraints
+        - name: Verify location constraints
           vars:
             __test_role_promoted: "{%
                 if __test_new_roles_pcs
@@ -544,7 +544,7 @@
                 that:
                   - __test_pcs_location_config.stdout_lines == __test_expected_lines | select | list
 
-        - name: Get colocation constraints
+        - name: Verify colocation constraints
           vars:
             __test_expected_lines:
               - 'Colocation Constraints:'
@@ -585,7 +585,7 @@
                 that:
                   - __test_pcs_colocation_config.stdout_lines == __test_expected_lines | select | list
 
-        - name: Get order constraints
+        - name: Verify order constraints
           vars:
             __test_expected_lines:
               - 'Ordering Constraints:'
@@ -618,7 +618,7 @@
                 that:
                   - __test_pcs_order_config.stdout_lines == __test_expected_lines | select | list
 
-        - name: Get ticket constraints
+        - name: Verify ticket constraints
           vars:
             __test_expected_lines:
               - 'Ticket Constraints:'

--- a/tests/tests_cib_properties_empty.yml
+++ b/tests/tests_cib_properties_empty.yml
@@ -11,7 +11,9 @@
     ha_cluster_manage_firewall: true
 
   tasks:
-    - block:
+    - name: Run test
+      tags: tests::verify
+      block:
         - name: Set up test environment
           include_role:
             name: linux-system-roles.ha_cluster
@@ -34,5 +36,3 @@
 
         - name: Check firewall and selinux state
           include_tasks: tasks/check_firewall_selinux.yml
-
-      tags: tests::verify

--- a/tests/tests_cib_properties_one_set.yml
+++ b/tests/tests_cib_properties_one_set.yml
@@ -14,7 +14,9 @@
     ha_cluster_manage_firewall: true
     ha_cluster_manage_selinux: true
   tasks:
-    - block:
+    - name: Run test
+      tags: tests::verify
+      block:
         - name: Set up test environment
           include_role:
             name: linux-system-roles.ha_cluster
@@ -47,5 +49,3 @@
 
         - name: Check firewall and selinux state
           include_tasks: tasks/check_firewall_selinux.yml
-
-      tags: tests::verify

--- a/tests/tests_cib_resources_create.yml
+++ b/tests/tests_cib_resources_create.yml
@@ -258,7 +258,9 @@
                 value: a value
 
   tasks:
-    - block:
+    - name: Run test
+      tags: tests::verify
+      block:
         - name: Set up test environment
           include_role:
             name: linux-system-roles.ha_cluster
@@ -273,7 +275,23 @@
           include_tasks: tasks/fetch_versions.yml
 
         # yamllint disable rule:line-length
-        - block:
+        - name: Get stonith configuration
+          when:
+            - '"pcmk.resource.config.output-formats" not in __test_pcs_capabilities'
+          vars:
+            __test_expected_lines:
+              - ' Resource: fence-no-attrs (class=stonith type=fence_kdump)'
+              - '  Operations: monitor interval=60s (fence-no-attrs-monitor-interval-60s)'
+              - ' Resource: fence-empty-attrs1 (class=stonith type=fence_kdump)'
+              - '  Operations: monitor interval=60s (fence-empty-attrs1-monitor-interval-60s)'
+              - ' Resource: fence-empty-attrs2 (class=stonith type=fence_kdump)'
+              - '  Operations: monitor interval=60s (fence-empty-attrs2-monitor-interval-60s)'
+              - ' Resource: fence-with-attrs (class=stonith type=fence_kdump)'
+              - '  Attributes: pcmk_host_list="node1 node2" timeout=30'
+              - '  Meta Attrs: an-attr="a value" target-role=Stopped'
+              - '  Operations: monitor interval=26 timeout=13 (fence-with-attrs-monitor-interval-26)'
+              - '              monitor interval=28s timeout=14s (fence-with-attrs-monitor-interval-28s)'
+          block:
             - name: Fetch stonith configuration from the cluster
               command:
                 cmd: pcs stonith config
@@ -292,41 +310,8 @@
               assert:
                 that:
                   - __test_pcs_stonith_config.stdout_lines == __test_expected_lines | select | list
-          when:
-            - '"pcmk.resource.config.output-formats" not in __test_pcs_capabilities'
-          vars:
-            __test_expected_lines:
-              - ' Resource: fence-no-attrs (class=stonith type=fence_kdump)'
-              - '  Operations: monitor interval=60s (fence-no-attrs-monitor-interval-60s)'
-              - ' Resource: fence-empty-attrs1 (class=stonith type=fence_kdump)'
-              - '  Operations: monitor interval=60s (fence-empty-attrs1-monitor-interval-60s)'
-              - ' Resource: fence-empty-attrs2 (class=stonith type=fence_kdump)'
-              - '  Operations: monitor interval=60s (fence-empty-attrs2-monitor-interval-60s)'
-              - ' Resource: fence-with-attrs (class=stonith type=fence_kdump)'
-              - '  Attributes: pcmk_host_list="node1 node2" timeout=30'
-              - '  Meta Attrs: an-attr="a value" target-role=Stopped'
-              - '  Operations: monitor interval=26 timeout=13 (fence-with-attrs-monitor-interval-26)'
-              - '              monitor interval=28s timeout=14s (fence-with-attrs-monitor-interval-28s)'
 
-        - block:
-            - name: Fetch stonith configuration from the cluster
-              command:
-                cmd: pcs --output-format=json stonith config
-              register: __test_pcs_stonith_config
-              changed_when: false
-
-            - name: Print real stonith configuration
-              debug:
-                var: __test_pcs_stonith_config.stdout | from_json
-
-            - name: Print expected stonith configuration
-              debug:
-                var: __test_expected_lines | from_json
-
-            - name: Check stonith configuration
-              assert:
-                that:
-                  - __test_pcs_stonith_config.stdout | from_json == __test_expected_lines | from_json
+        - name: Get stonith configuration
           when:
             - "'pcmk.resource.config.output-formats' in __test_pcs_capabilities"
           vars:
@@ -505,29 +490,31 @@
                     "groups": [],
                     "bundles": []
                 }
-
-        - block:
-            - name: Fetch resource configuration from the cluster
+          block:
+            - name: Fetch stonith configuration from the cluster
               command:
-                cmd: pcs resource config
-              register: __test_pcs_resource_config
+                cmd: pcs --output-format=json stonith config
+              register: __test_pcs_stonith_config
               changed_when: false
 
-            - name: Print real resource configuration
+            - name: Print real stonith configuration
               debug:
-                var: __test_pcs_resource_config.stdout_lines
+                var: __test_pcs_stonith_config.stdout | from_json
 
-            - name: Print expected resource configuration
+            - name: Print expected stonith configuration
               debug:
-                var: __test_expected_lines | select | list
+                var: __test_expected_lines | from_json
 
-            - name: Check resource configuration
+            - name: Check stonith configuration
               assert:
                 that:
-                  - __test_pcs_resource_config.stdout_lines == __test_expected_lines | select | list
+                  - __test_pcs_stonith_config.stdout | from_json == __test_expected_lines | from_json
+
+        - name: Get resource configuration
           when:
             - '"pcmk.resource.config.output-formats" not in __test_pcs_capabilities'
           vars:
+            # noqa jinja[spacing]
             __test_expected_lines:
               - ' Bundle: bundle-minimal'
               - '  Docker: image=my:image1'
@@ -751,36 +738,35 @@
                 '') }}"
               - '                start interval=0s timeout=20s (dummy-3a-start-interval-0s)'
               - '                stop interval=0s timeout=20s (dummy-3a-stop-interval-0s)'
-
-        - block:
+          block:
             - name: Fetch resource configuration from the cluster
               command:
-                cmd: pcs --output-format=json resource config
+                cmd: pcs resource config
               register: __test_pcs_resource_config
               changed_when: false
 
             - name: Print real resource configuration
               debug:
-                var: __test_pcs_resource_config.stdout | from_json
+                var: __test_pcs_resource_config.stdout_lines
 
             - name: Print expected resource configuration
               debug:
-                var: __test_expected_lines | from_json
+                var: __test_expected_lines | select | list
 
             - name: Check resource configuration
               assert:
                 that:
-                  - __test_pcs_resource_config.stdout | from_json == __test_expected_lines | from_json
+                  - __test_pcs_resource_config.stdout_lines == __test_expected_lines | select | list
+
+        - name: Get resource configuration
           when:
             - "'pcmk.resource.config.output-formats' in __test_pcs_capabilities"
           vars:
             __old_roles: "{{
-              (
-                ansible_facts['distribution'] in ['RedHat', 'CentOS']
-                and
-                ansible_facts['distribution_major_version'] == '8'
-              ) | bool
-              }}"
+              (ansible_facts['distribution'] in ['RedHat', 'CentOS']
+               and
+               ansible_facts['distribution_major_version'] == '8') |
+               bool }}"
             __promoted: "{{ __old_roles | ternary('Master', 'Promoted') }}"
             __unpromoted: "{{ __old_roles | ternary('Slave', 'Unpromoted') }}"
             __test_expected_lines: '
@@ -3356,11 +3342,25 @@
                             ]
                         }
                     ]
-                }
-            '
+                }'
+          block:
+            - name: Fetch resource configuration from the cluster
+              command:
+                cmd: pcs --output-format=json resource config
+              register: __test_pcs_resource_config
+              changed_when: false
+
+            - name: Print real resource configuration
+              debug:
+                var: __test_pcs_resource_config.stdout | from_json
+
+            - name: Print expected resource configuration
+              debug:
+                var: __test_expected_lines | from_json
+
+            - name: Check resource configuration
+              assert:
+                that:
+                  - __test_pcs_resource_config.stdout | from_json == __test_expected_lines | from_json
         - name: Check firewall and selinux state
           include_tasks: tasks/check_firewall_selinux.yml
-
-      # yamllint enable rule:line-length
-
-      tags: tests::verify

--- a/tests/tests_cib_resources_create.yml
+++ b/tests/tests_cib_resources_create.yml
@@ -275,7 +275,7 @@
           include_tasks: tasks/fetch_versions.yml
 
         # yamllint disable rule:line-length
-        - name: Get stonith configuration
+        - name: Verify stonith configuration
           when:
             - '"pcmk.resource.config.output-formats" not in __test_pcs_capabilities'
           vars:
@@ -311,7 +311,7 @@
                 that:
                   - __test_pcs_stonith_config.stdout_lines == __test_expected_lines | select | list
 
-        - name: Get stonith configuration
+        - name: Verify stonith configuration
           when:
             - "'pcmk.resource.config.output-formats' in __test_pcs_capabilities"
           vars:
@@ -510,7 +510,7 @@
                 that:
                   - __test_pcs_stonith_config.stdout | from_json == __test_expected_lines | from_json
 
-        - name: Get resource configuration
+        - name: Verify resource configuration
           when:
             - '"pcmk.resource.config.output-formats" not in __test_pcs_capabilities'
           vars:
@@ -758,7 +758,7 @@
                 that:
                   - __test_pcs_resource_config.stdout_lines == __test_expected_lines | select | list
 
-        - name: Get resource configuration
+        - name: Verify resource configuration
           when:
             - "'pcmk.resource.config.output-formats' in __test_pcs_capabilities"
           vars:
@@ -3362,5 +3362,6 @@
               assert:
                 that:
                   - __test_pcs_resource_config.stdout | from_json == __test_expected_lines | from_json
+
         - name: Check firewall and selinux state
           include_tasks: tasks/check_firewall_selinux.yml

--- a/tests/tests_cluster_advanced_knet_full.yml
+++ b/tests/tests_cluster_advanced_knet_full.yml
@@ -47,7 +47,9 @@
           value: 1
 
   tasks:
-    - block:
+    - name: Run test
+      tags: tests::verify
+      block:
         - name: Set up test environment
           include_role:
             name: linux-system-roles.ha_cluster
@@ -61,8 +63,7 @@
               # batch, first and flatten.
               corosync_addresses: "{{
                 lookup('pipe', 'getent hosts ' + inventory_hostname)
-                | regex_findall('\\S+') | batch(2) | first | flatten
-              }}"
+                | regex_findall('\\S+') | batch(2) | first | flatten }}"
 
         - name: Run HA Cluster role
           include_role:
@@ -122,4 +123,3 @@
         - name: Unset node addresses variable
           set_fact:
             ha_cluster:
-      tags: tests::verify

--- a/tests/tests_cluster_advanced_knet_implicit.yml
+++ b/tests/tests_cluster_advanced_knet_implicit.yml
@@ -13,7 +13,9 @@
           value: none
 
   tasks:
-    - block:
+    - name: Run test
+      tags: tests::verify
+      block:
         - name: Set up test environment
           include_role:
             name: linux-system-roles.ha_cluster
@@ -30,6 +32,7 @@
         - name: Check corosync
           include_tasks: tasks/assert_corosync_config.yml
           vars:
+            # noqa jinja[spacing]
             __test_expected_lines:
               - 'totem {'
               - '    version: 2'
@@ -58,5 +61,3 @@
 
         - name: Check firewall and selinux state
           include_tasks: tasks/check_firewall_selinux.yml
-
-      tags: tests::verify

--- a/tests/tests_cluster_advanced_udp_full.yml
+++ b/tests/tests_cluster_advanced_udp_full.yml
@@ -32,7 +32,9 @@
           value: 1
 
   tasks:
-    - block:
+    - name: Run test
+      tags: tests::verify
+      block:
         - name: Set up test environment
           include_role:
             name: linux-system-roles.ha_cluster
@@ -83,5 +85,3 @@
 
         - name: Check firewall and selinux state
           include_tasks: tasks/check_firewall_selinux.yml
-
-      tags: tests::verify

--- a/tests/tests_cluster_basic.yml
+++ b/tests/tests_cluster_basic.yml
@@ -7,7 +7,9 @@
     ha_cluster_cluster_name: test-cluster
 
   tasks:
-    - block:
+    - name: Run test
+      tags: tests::verify
+      block:
         - name: Set up test environment
           include_role:
             name: linux-system-roles.ha_cluster
@@ -80,6 +82,7 @@
         - name: Check corosync
           include_tasks: tasks/assert_corosync_config.yml
           vars:
+            # noqa jinja[spacing]
             __test_expected_lines:
               - 'totem {'
               - '    version: 2'
@@ -108,5 +111,3 @@
 
         - name: Check firewall and selinux state
           include_tasks: tasks/check_firewall_selinux.yml
-
-      tags: tests::verify

--- a/tests/tests_cluster_basic_custom_fence_agents.yml
+++ b/tests/tests_cluster_basic_custom_fence_agents.yml
@@ -9,7 +9,9 @@
       - fence-agents-ipmilan
 
   tasks:
-    - block:
+    - name: Run test
+      tags: tests::verify
+      block:
         - name: Set up test environment
           include_role:
             name: linux-system-roles.ha_cluster
@@ -36,5 +38,3 @@
 
         - name: Check cluster status
           include_tasks: tasks/assert_cluster_running.yml
-
-      tags: tests::verify

--- a/tests/tests_cluster_basic_custom_packages.yml
+++ b/tests/tests_cluster_basic_custom_packages.yml
@@ -10,7 +10,9 @@
       - "{{ __test_extra_package }}"
 
   tasks:
-    - block:
+    - name: Run test
+      tags: tests::verify
+      block:
         - name: Set up test environment
           include_role:
             name: linux-system-roles.ha_cluster
@@ -33,5 +35,3 @@
           assert:
             that:
               - "'{{ __test_extra_package }}' in ansible_facts.packages"
-
-      tags: tests::verify

--- a/tests/tests_cluster_basic_custom_pcsd_tls.yml
+++ b/tests/tests_cluster_basic_custom_pcsd_tls.yml
@@ -7,16 +7,17 @@
     ha_cluster_cluster_name: test-cluster
     ha_cluster_pcsd_public_key_src: "{{ __ha_cluster_work_dir.path }}/pcsd.crt"
     ha_cluster_pcsd_private_key_src: "{{ __ha_cluster_work_dir.path }}/pcsd.key"
-
   tasks:
-    - block:
+    - name: Run test
+      tags: tests::verify
+      block:
         - name: Create temp directory for secrets
           tempfile:
             state: directory
             prefix: lsr_ha_cluster_
           register: __ha_cluster_work_dir
           delegate_to: localhost
-          run_once: true
+          run_once: true  # noqa: run_once[task]
 
         - name: Set up test environment
           include_role:
@@ -79,13 +80,10 @@
 
         - name: Check firewall and selinux state
           include_tasks: tasks/check_firewall_selinux.yml
-
-      tags: tests::verify
-
       always:
         - name: Clean up work directory
           file:
             path: "{{ __ha_cluster_work_dir.path }}"
             state: absent
           delegate_to: localhost
-          run_once: true
+          run_once: true  # noqa: run_once[task]

--- a/tests/tests_cluster_basic_custom_pcsd_tls_cert_role.yml
+++ b/tests/tests_cluster_basic_custom_pcsd_tls_cert_role.yml
@@ -10,7 +10,9 @@
     __cert_name: pcsd_cert
 
   tasks:
-    - block:
+    - name: Run test
+      tags: tests::verify
+      block:
         - name: Set up test environment
           include_role:
             name: linux-system-roles.ha_cluster
@@ -46,5 +48,3 @@
 
         - name: Check firewall and selinux state
           include_tasks: tasks/check_firewall_selinux.yml
-
-      tags: tests::verify

--- a/tests/tests_cluster_basic_disabled.yml
+++ b/tests/tests_cluster_basic_disabled.yml
@@ -8,7 +8,9 @@
     ha_cluster_start_on_boot: false
 
   tasks:
-    - block:
+    - name: Run test
+      tags: tests::verify
+      block:
         - name: Set up test environment
           include_role:
             name: linux-system-roles.ha_cluster
@@ -34,5 +36,3 @@
 
         - name: Check firewall and selinux state
           include_tasks: tasks/check_firewall_selinux.yml
-
-      tags: tests::verify

--- a/tests/tests_cluster_basic_existing_psks.yml
+++ b/tests/tests_cluster_basic_existing_psks.yml
@@ -14,14 +14,16 @@
     __test_fence_xvm_key_path: "{{ __ha_cluster_work_dir.path }}/fence_xvm.key"
 
   tasks:
-    - block:
+    - name: Run test
+      tags: tests::verify
+      block:
         - name: Create temp directory for secrets
           tempfile:
             state: directory
             prefix: lsr_ha_cluster_
           register: __ha_cluster_work_dir
           delegate_to: localhost
-          run_once: true
+          run_once: true  # noqa: run_once[task]
 
         - name: Set up test environment
           include_role:
@@ -210,13 +212,10 @@
 
         - name: Check firewall and selinux state
           include_tasks: tasks/check_firewall_selinux.yml
-
-      tags: tests::verify
-
       always:
         - name: Clean up work directory
           file:
             path: "{{ __ha_cluster_work_dir.path }}"
             state: absent
           delegate_to: localhost
-          run_once: true
+          run_once: true  # noqa: run_once[task]

--- a/tests/tests_cluster_basic_new_psks.yml
+++ b/tests/tests_cluster_basic_new_psks.yml
@@ -18,14 +18,16 @@
     __test_pcsd_public_key_path: "{{ __ha_cluster_work_dir.path }}/pcsd.crt"
 
   tasks:
-    - block:
+    - name: Run test
+      tags: tests::verify
+      block:
         - name: Create temp directory for secrets
           tempfile:
             state: directory
             prefix: lsr_ha_cluster_
           register: __ha_cluster_work_dir
           delegate_to: localhost
-          run_once: true
+          run_once: true  # noqa: run_once[task]
 
         - name: Set up test environment
           include_role:
@@ -178,13 +180,10 @@
 
         - name: Check firewall and selinux state
           include_tasks: tasks/check_firewall_selinux.yml
-
-      tags: tests::verify
-
       always:
         - name: Clean up work directory
           file:
             path: "{{ __ha_cluster_work_dir.path }}"
             state: absent
           delegate_to: localhost
-          run_once: true
+          run_once: true  # noqa: run_once[task]

--- a/tests/tests_cluster_destroy.yml
+++ b/tests/tests_cluster_destroy.yml
@@ -6,7 +6,9 @@
     ha_cluster_cluster_present: false
 
   tasks:
-    - block:
+    - name: Run test
+      tags: tests::verify
+      block:
         - name: Set up test environment
           include_role:
             name: linux-system-roles.ha_cluster
@@ -38,5 +40,3 @@
               - not stat_corosync_conf.stat.exists
               - not stat_cib_xml.stat.exists
               - not stat_fence_xvm_key.stat.exists
-
-      tags: tests::verify

--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -4,7 +4,9 @@
   hosts: all
   gather_facts: false
   tasks:
-    - block:
+    - name: Run test
+      tags: tests::verify
+      block:
         - name: Run the role
           include_role:
             name: linux-system-roles.ha_cluster
@@ -12,16 +14,12 @@
         - name: Extract errors
           set_fact:
             error_list: "{{
-              ansible_failed_result.results | map(attribute='msg') | list
-            }}"
-          run_once: true
+              ansible_failed_result.results | map(attribute='msg') |
+              list }}"
+          run_once: true  # noqa: run_once[task]
 
         - name: Check errors
           assert:
             that:
-              - "{{
-                  'ha_cluster_hacluster_password must be specified'
-                  in error_list
-                }}"
-
-      tags: tests::verify
+              - "'ha_cluster_hacluster_password must be specified'
+                  in error_list"

--- a/tests/tests_include_vars_from_parent.yml
+++ b/tests/tests_include_vars_from_parent.yml
@@ -3,7 +3,7 @@
   gather_facts: true
   hosts: all
   tasks:
-    - name: create var file in caller that can override the one in called role
+    - name: Create var file in caller that can override the one in called role
       delegate_to: localhost
       copy:
         # usually the fake file will cause the called role to crash of
@@ -44,7 +44,8 @@
         name: linux-system-roles.ha_cluster
         tasks_from: test_setup.yml
 
-    - import_role:
+    - name: Import role
+      import_role:
         name: caller
       vars:
         roletoinclude: linux-system-roles.ha_cluster

--- a/tests/tests_qdevice_all_options.yml
+++ b/tests/tests_qdevice_all_options.yml
@@ -5,9 +5,10 @@
   vars_files: vars/main.yml
   vars:
     ha_cluster_cluster_name: test-cluster
-
   tasks:
-    - block:
+    - name: Run test
+      tags: tests::verify
+      block:
         - name: Set up test environment
           include_role:
             name: linux-system-roles.ha_cluster
@@ -17,20 +18,19 @@
           include_role:
             name: linux-system-roles.ha_cluster
             tasks_from: test_setup_qnetd.yml
-          run_once: true
+          run_once: true  # noqa: run_once[task]
 
         - name: Back up qnetd
           include_tasks: tasks/qnetd_backup_restore.yml
           vars:
             action: backup
-          run_once: true
+          run_once: true  # noqa: run_once[task]
 
         - name: Set qnetd address
           set_fact:
             __test_qnetd_address: "{{
                 (ansible_play_hosts_all | length == 1)
-                | ternary('localhost', ansible_play_hosts[0])
-              }}"
+                | ternary('localhost', ansible_play_hosts[0]) }}"
 
         - name: Run HA Cluster role
           include_role:
@@ -60,7 +60,7 @@
           include_tasks: tasks/qnetd_backup_restore.yml
           vars:
             action: restore
-          run_once: true
+          run_once: true  # noqa: run_once[task]
 
         - name: Get services status
           service_facts:
@@ -114,5 +114,3 @@
 
         - name: Check qdevice status
           include_tasks: tasks/assert_qdevice_in_cluster.yml
-
-      tags: tests::verify

--- a/tests/tests_qdevice_minimal.yml
+++ b/tests/tests_qdevice_minimal.yml
@@ -7,7 +7,9 @@
     ha_cluster_cluster_name: test-cluster
 
   tasks:
-    - block:
+    - name: Run test
+      tags: tests::verify
+      block:
         - name: Set up test environment
           include_role:
             name: linux-system-roles.ha_cluster
@@ -22,20 +24,19 @@
           include_role:
             name: linux-system-roles.ha_cluster
             tasks_from: test_setup_qnetd.yml
-          run_once: true
+          run_once: true  # noqa: run_once[task]
 
         - name: Back up qnetd
           include_tasks: tasks/qnetd_backup_restore.yml
           vars:
             action: backup
-          run_once: true
+          run_once: true  # noqa: run_once[task]
 
         - name: Set qnetd address
           set_fact:
             __test_qnetd_address: "{{
                 (ansible_play_hosts_all | length == 1)
-                | ternary('localhost', ansible_play_hosts[0])
-              }}"
+                | ternary('localhost', ansible_play_hosts[0]) }}"
 
         - name: Run HA Cluster role
           include_role:
@@ -55,7 +56,7 @@
           include_tasks: tasks/qnetd_backup_restore.yml
           vars:
             action: restore
-          run_once: true
+          run_once: true  # noqa: run_once[task]
 
         - name: Get services status
           service_facts:
@@ -109,4 +110,3 @@
           include_role:
             name: linux-system-roles.ha_cluster
             tasks_from: test_cleanup_qnetd.yml
-      tags: tests::verify

--- a/tests/tests_qnetd.yml
+++ b/tests/tests_qnetd.yml
@@ -8,7 +8,9 @@
     ha_cluster_qnetd:
       present: true
   tasks:
-    - block:
+    - name: Run test
+      tags: tests::verify
+      block:
         - name: Set up test environment
           include_role:
             name: linux-system-roles.ha_cluster
@@ -33,5 +35,3 @@
                 == "enabled"
               - ansible_facts.services["corosync-qnetd.service"].state
                  == "running"
-
-      tags: tests::verify

--- a/tests/tests_qnetd_and_cluster.yml
+++ b/tests/tests_qnetd_and_cluster.yml
@@ -7,7 +7,9 @@
     ha_cluster_qnetd:
       present: true
   tasks:
-    - block:
+    - name: Run test
+      tags: tests::verify
+      block:
         - name: Run HA Cluster role
           include_role:
             name: linux-system-roles.ha_cluster
@@ -15,9 +17,5 @@
         - name: Check errors
           assert:
             that:
-              - "{{
-                  'Qnetd cannot be configured on a cluster node'
-                  in ansible_failed_result.msg
-                }}"
-
-      tags: tests::verify
+              - "'Qnetd cannot be configured on a cluster node'
+                  in ansible_failed_result.msg"

--- a/tests/tests_qnetd_disabled.yml
+++ b/tests/tests_qnetd_disabled.yml
@@ -9,7 +9,9 @@
       present: true
       start_on_boot: false
   tasks:
-    - block:
+    - name: Run test
+      tags: tests::verify
+      block:
         - name: Set up test environment
           include_role:
             name: linux-system-roles.ha_cluster
@@ -34,5 +36,3 @@
                 == "disabled"
               - ansible_facts.services["corosync-qnetd.service"].state
                  == "running"
-
-      tags: tests::verify

--- a/tests/tests_sbd_all_options.yml
+++ b/tests/tests_sbd_all_options.yml
@@ -17,7 +17,9 @@
         value: 10
 
   tasks:
-    - block:
+    - name: Run test
+      tags: tests::verify
+      block:
         - name: Set up test environment
           include_role:
             name: linux-system-roles.ha_cluster
@@ -82,4 +84,3 @@
           include_role:
             name: linux-system-roles.ha_cluster
             tasks_from: test_cleanup_sbd.yml
-      tags: tests::verify

--- a/tests/tests_sbd_check_devices_count.yml
+++ b/tests/tests_sbd_check_devices_count.yml
@@ -7,7 +7,10 @@
     ha_cluster_sbd_enabled: true
 
   tasks:
-    - block:
+    - name: Run test
+      when: ansible_play_hosts_all | length > 1
+      tags: tests::verify
+      block:
         - name: Set up test environment
           include_role:
             name: linux-system-roles.ha_cluster
@@ -19,32 +22,29 @@
               sbd_devices: "{{
                   range(1, ansible_play_hosts_all.index(inventory_hostname) + 2)
                   | product(['/tmp/dev/sdx']) | map('reverse') | map('join')
-                  | list
-                }}"
+                  | list }}"
 
         - name: Print set SBD devices
           debug:
             var: ha_cluster.sbd_devices
 
-        - block:
+        - name: Run the role and check for errors
+          block:
             - name: Run the role
               include_role:
                 name: linux-system-roles.ha_cluster
           rescue:
             - name: Check errors
               assert:
-                that: "{{
-                  ansible_failed_result.msg ==
-                  'All nodes must have the same number of SBD devices specified'
-                }}"
-              run_once: true
-
-      when: ansible_play_hosts_all | length > 1
+                that: ansible_failed_result.msg == expected_msg
+              run_once: true  # noqa: run_once[task]
+              vars:
+                expected_msg: >-
+                  All nodes must have the same number of SBD devices specified
       always:
         - name: Unset SBD devices variable
           set_fact:
             ha_cluster:
-      tags: tests::verify
 
     - name: Message
       debug:

--- a/tests/tests_sbd_defaults.yml
+++ b/tests/tests_sbd_defaults.yml
@@ -8,7 +8,9 @@
     ha_cluster_sbd_enabled: true
 
   tasks:
-    - block:
+    - name: Run test
+      tags: tests::verify
+      block:
         - name: Set up test environment
           include_role:
             name: linux-system-roles.ha_cluster
@@ -37,8 +39,7 @@
         - name: Decode SBD config
           set_fact:
             __test_sbd_config_lines: "{{
-                (__test_sbd_config.content | b64decode).splitlines()
-              }}"
+                (__test_sbd_config.content | b64decode).splitlines() }}"
 
         - name: Print SBD config lines
           debug:
@@ -98,4 +99,3 @@
           include_role:
             name: linux-system-roles.ha_cluster
             tasks_from: test_cleanup_sbd.yml
-      tags: tests::verify

--- a/tests/tests_sbd_defaults_disabled.yml
+++ b/tests/tests_sbd_defaults_disabled.yml
@@ -9,7 +9,9 @@
     ha_cluster_sbd_enabled: true
 
   tasks:
-    - block:
+    - name: Run test
+      tags: tests::verify
+      block:
         - name: Set up test environment
           include_role:
             name: linux-system-roles.ha_cluster
@@ -49,4 +51,3 @@
           include_role:
             name: linux-system-roles.ha_cluster
             tasks_from: test_cleanup_sbd.yml
-      tags: tests::verify

--- a/tests/tests_sbd_needs_atb_while_atb_disabled.yml
+++ b/tests/tests_sbd_needs_atb_while_atb_disabled.yml
@@ -11,7 +11,10 @@
           value: 0
 
   tasks:
-    - block:
+    - name: Run test
+      tags: tests::verify
+      when: ansible_play_hosts_all | length is even
+      block:
         - name: Set up test environment
           include_role:
             name: linux-system-roles.ha_cluster
@@ -27,7 +30,8 @@
             ha_cluster:
               sbd_devices: []
 
-        - block:
+        - name: Run the role and check errors
+          block:
             - name: Run the role
               include_role:
                 name: linux-system-roles.ha_cluster
@@ -38,9 +42,7 @@
                   - ansible_failed_result.msg ==
                     'Cannot set auto_tie_breaker to disabled when SBD needs it '
                     ~ 'to be enabled'
-              run_once: true
-
-      when: ansible_play_hosts_all | length is even
+              run_once: true  # noqa: run_once[task]
       always:
         - name: Unset SBD devices variable
           set_fact:
@@ -50,7 +52,6 @@
           include_role:
             name: linux-system-roles.ha_cluster
             tasks_from: test_cleanup_sbd.yml
-      tags: tests::verify
 
     - name: Message
       debug:

--- a/tests/tests_sbd_needs_atb_while_atb_enabled.yml
+++ b/tests/tests_sbd_needs_atb_while_atb_enabled.yml
@@ -11,7 +11,10 @@
           value: 1
 
   tasks:
-    - block:
+    - name: Run test
+      tags: tests::verify
+      when: ansible_play_hosts_all | length is even
+      block:
         - name: Set up test environment
           include_role:
             name: linux-system-roles.ha_cluster
@@ -49,8 +52,6 @@
 
         - name: Check firewall and selinux state
           include_tasks: tasks/check_firewall_selinux.yml
-
-      when: ansible_play_hosts_all | length is even
       always:
         - name: Unset SBD devices variable
           set_fact:
@@ -60,7 +61,6 @@
           include_role:
             name: linux-system-roles.ha_cluster
             tasks_from: test_cleanup_sbd.yml
-      tags: tests::verify
 
     - name: Message
       debug:


### PR DESCRIPTION
* All tasks and plays must be named - even blocks
* In blocks, all parameters should come before block, then rescue, then always
* Fix some jinja spacing, suppress some warnings
* ansible-lint does not like the `run_once: true` in the tests, so suppress
