### PR TITLE
Fence agent firewall port is restricted to x86_64 architecture.

### DIFF
--- a/tasks/selinux.yml
+++ b/tasks/selinux.yml
@@ -15,6 +15,7 @@
           - {'ports': '1229', 'proto': 'tcp', 'setype': 'cluster_port_t',
              'state': 'present', 'local': true}
       when:
+        - ansible_facts['architecture'] == 'x86_64'
         - (
             'fence-virt' in ha_cluster_fence_agent_packages
             or

--- a/tests/tasks/check_firewall_selinux.yml
+++ b/tests/tasks/check_firewall_selinux.yml
@@ -10,6 +10,7 @@
       changed_when: false
 
     - name: Check firewall port status
+      when: ansible_facts['architecture'] == 'x86_64'
       command: firewall-cmd --list-ports
       register: _result
       failed_when: "'1229/tcp' not in _result.stdout"


### PR DESCRIPTION
Add the condition to tests/tasks/check_firewall_selinux.yml and tasks/selinux.yml.