### PR TITLE
Fingerprint RHEL System Role managed config files

### DIFF
--- a/templates/sbd
+++ b/templates/sbd
@@ -1,4 +1,5 @@
 {{ ansible_managed | comment }}
+{{ "system_role:ha_cluster" | comment(prefix="", postfix="") }}
 
 {% macro option(ansible_name, default_value) -%}
   {%- for option in options if option.name == ansible_name -%}


### PR DESCRIPTION
Add role name to the generated config files. 
```
# system_role:ha_cluster
```
Note: This info is introduced to help customers to identify that it was generated by System Roles. Also, it could be used in future analysis.