### PR TITLE
fix ansible-lint issues with changed_when, others

### DIFF
--- a/tasks/cluster-setup-keys.yml
+++ b/tasks/cluster-setup-keys.yml
@@ -40,6 +40,7 @@
   when:
     - not ansible_check_mode
     - __ha_cluster_qdevice_model != "net" or ha_cluster_regenerate_keys
+  changed_when: true
 
 - name: Obtain and distribute qdevice certificates
   script:

--- a/tasks/cluster-start-and-reload.yml
+++ b/tasks/cluster-start-and-reload.yml
@@ -58,6 +58,7 @@
     cmd: corosync-cfgtool -R
   run_once: true  # noqa: run_once[task]
   when: not ansible_check_mode
+  changed_when: false
 
 - name: Start corosync-qdevice
   service:
@@ -88,6 +89,7 @@
 - name: List pacemaker nodes
   shell:
     cmd: >
+      set -euo pipefail;
       crm_mon -X
       | xmllint --xpath '/crm_mon/nodes/node/@name' -
       | sed -E 's/\s*name="([^"]+)"\s*/\1\n/g'
@@ -115,6 +117,10 @@
   # Check mode does not start the cluster, it only shows the cluster would be
   # started.
   when:
+    - not ansible_check_mode
+    - (item | length) > 0
+    - item not in __ha_cluster_all_node_names
+  changed_when:
     - not ansible_check_mode
     - (item | length) > 0
     - item not in __ha_cluster_all_node_names

--- a/tasks/create-and-push-cib.yml
+++ b/tasks/create-and-push-cib.yml
@@ -256,6 +256,7 @@
       cibadmin --verbose --patch
       --xml-file {{ __ha_cluster_tempfile_cib_diff.path | quote }}
   run_once: true  # noqa: run_once[task]
+  changed_when: not ansible_check_mode
   when: __ha_cluster_cib_diff.rc == 1
 
 - name: Remove CIB tempfiles

--- a/tasks/enable-repositories/CentOS.yml
+++ b/tasks/enable-repositories/CentOS.yml
@@ -12,3 +12,4 @@
     cmd: dnf config-manager --set-enabled {{ item.id | quote }}
   loop: "{{ __ha_cluster_repos }}"
   when: item.name not in __ha_cluster_repolist.stdout
+  changed_when: item.name not in __ha_cluster_repolist.stdout

--- a/tasks/enable-repositories/RedHat.yml
+++ b/tasks/enable-repositories/RedHat.yml
@@ -11,3 +11,4 @@
   command: subscription-manager repos --enable {{ item.id | quote }}
   loop: "{{ __ha_cluster_repos }}"
   when: item.name not in __ha_cluster_repolist.stdout
+  changed_when: item.name not in __ha_cluster_repolist.stdout

--- a/tasks/pcs-qnetd.yml
+++ b/tasks/pcs-qnetd.yml
@@ -10,6 +10,7 @@
         not ha_cluster_qnetd.present | d(false)
         or ha_cluster_qnetd.regenerate_keys | d(false)
       )
+  changed_when: true
 
 - name: Manage qnetd
   when:

--- a/tasks/test_setup_sbd.yml
+++ b/tasks/test_setup_sbd.yml
@@ -10,8 +10,7 @@
   command: modprobe softdog
   changed_when: true
   # do not load if sbd tests are run (loads module instead)
-  when:
-  - not (__test_disable_modprobe | d(false))
+  when: not (__test_disable_modprobe | d(false))
 
 - name: Create backing files for SBD devices
   tempfile:


### PR DESCRIPTION
Ansible lint now requires the use of `changed_when:` with commands
even in some cases where the command has a `when` condition.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
