### PR TITLE
feat: cluster and quorum can have distinct passwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,14 @@ Password of the `hacluster` user. This user has full access to a cluster. It is
 recommended to vault encrypt the value, see
 https://docs.ansible.com/ansible/latest/user_guide/vault.html for details.
 
+#### `ha_cluster_hacluster_qdevice_password`
+
+string, no default - optional
+
+Needed only if a `ha_cluster_quorum` is configured to use a qdevice of type `net` used AND password of the `hacluster` user on the qdevice is different from `ha_cluster_hacluster_password`. This user has full access to a cluster. It is
+recommended to vault encrypt the value, see
+https://docs.ansible.com/ansible/latest/user_guide/vault.html for details.
+
 #### `ha_cluster_corosync_key_src`
 
 path to Corosync authkey file, default: `null`

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ https://docs.ansible.com/ansible/latest/user_guide/vault.html for details.
 
 string, no default - optional
 
-Needed only if a `ha_cluster_quorum` is configured to use a qdevice of type `net` used AND password of the `hacluster` user on the qdevice is different from `ha_cluster_hacluster_password`. This user has full access to a cluster. It is
+Needed only if a `ha_cluster_quorum` is configured to use a qdevice of type `net` AND password of the `hacluster` user on the qdevice is different from `ha_cluster_hacluster_password`. This user has full access to a cluster. It is
 recommended to vault encrypt the value, see
 https://docs.ansible.com/ansible/latest/user_guide/vault.html for details.
 

--- a/tasks/shell_pcs/pcs-auth-pcs-0.10.yml
+++ b/tasks/shell_pcs/pcs-auth-pcs-0.10.yml
@@ -24,7 +24,8 @@
       {% if __ha_cluster_qdevice_pcs_address %}
         addr={{ __ha_cluster_qdevice_pcs_address | quote }}
       {% endif %}
-    stdin: "{{ ha_cluster_hacluster_qdevice_password | default(ha_cluster_hacluster_password) }}"
+    stdin: "{{ ha_cluster_hacluster_qdevice_password |
+      d(ha_cluster_hacluster_password) }}"
   when:
     - __ha_cluster_qdevice_model == "net"
     - __ha_cluster_qdevice_host

--- a/tasks/shell_pcs/pcs-auth-pcs-0.10.yml
+++ b/tasks/shell_pcs/pcs-auth-pcs-0.10.yml
@@ -30,7 +30,7 @@
       d(ha_cluster_hacluster_password) }}"
   when:
     - __ha_cluster_qdevice_model == "net"
-    - __ha_cluster_qdevice_host
+    - __ha_cluster_qdevice_host | length > 0
     - __ha_cluster_qdevice_host not in __ha_cluster_all_node_names
   run_once: true  # noqa: run_once[task]
   changed_when: true

--- a/tasks/shell_pcs/pcs-auth-pcs-0.10.yml
+++ b/tasks/shell_pcs/pcs-auth-pcs-0.10.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+---
 - name: Pcs auth using pcs-0.10
   command:
     # Always auth all nodes to prevent possible corner cases with synchronizing

--- a/tasks/shell_pcs/pcs-auth-pcs-0.10.yml
+++ b/tasks/shell_pcs/pcs-auth-pcs-0.10.yml
@@ -1,5 +1,3 @@
-# SPDX-License-Identifier: MIT
----
 - name: Pcs auth using pcs-0.10
   command:
     # Always auth all nodes to prevent possible corner cases with synchronizing
@@ -12,15 +10,24 @@
           addr={{ hostvars[node].ha_cluster.pcs_address | quote }}
         {% endif %}
       {% endfor %}
-      {% if __ha_cluster_qdevice_model == "net" and __ha_cluster_qdevice_host %}
-        {# prevent pcs error: Host name defined multiple times #}
-        {% if  __ha_cluster_qdevice_host not in __ha_cluster_all_node_names %}
-          {{ __ha_cluster_qdevice_host | quote }}
-          {% if __ha_cluster_qdevice_pcs_address %}
-            addr={{ __ha_cluster_qdevice_pcs_address | quote }}
-          {% endif %}
-        {% endif %}
-      {% endif %}
     stdin: "{{ ha_cluster_hacluster_password }}"
+  run_once: true  # noqa: run_once[task]
+  changed_when: true
+
+- name: Pcs auth for qdevice using pcs-0.10
+  command:
+    # Always auth all nodes to prevent possible corner cases with synchronizing
+    # pcs auth tokens in the cluster when not all nodes are auth-ed.
+    cmd: >
+      pcs host auth -u hacluster --
+      {{ __ha_cluster_qdevice_host | quote }}
+      {% if __ha_cluster_qdevice_pcs_address %}
+        addr={{ __ha_cluster_qdevice_pcs_address | quote }}
+      {% endif %}
+    stdin: "{{ ha_cluster_hacluster_qdevice_password | default(ha_cluster_hacluster_password) }}"
+  when:
+    - __ha_cluster_qdevice_model == "net"
+    - __ha_cluster_qdevice_host
+    - __ha_cluster_qdevice_host not in __ha_cluster_all_node_names
   run_once: true  # noqa: run_once[task]
   changed_when: true


### PR DESCRIPTION
Enhancement: cluster and quorum can have distinct passwords

Reason: The same quorum hosts can be joined to multiple, separate clusters. Since the passwords of the "hacluster" user on these clusters might be different, it makes sense to configure them separately.

Result: I separated `pcs auth` for the cluster and qdevice. I also introduced an new var `ha_cluster_hacluster_qdevice_password`, which is used for qdevice auth. If the new var is not set, qdevice auth will fall back to use `ha_cluster_hacluster_password` like rest of the cluster. This should make the change fully backwards compatible. 

Issue Tracker Tickets (Jira or BZ if any): none
