### PR TITLE
feat: add an option to enable Resilient Storage rpm repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ boolean, default: `true`
 
 RHEL and CentOS only, enable repositories containing needed packages
 
+#### `ha_cluster_enable_repos_resilient_storage`
+
+boolean, default: `false`
+
+RHEL and CentOS only, enable repositories containing resilient storage
+packages, such as dlm or gfs2. For this option to take effect,
+`ha_cluster_enable_repos` must be set to `true`.
+
 #### `ha_cluster_manage_firewall`
 
 boolean, default: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@
 ha_cluster_pacemaker_shell: pcs
 
 ha_cluster_enable_repos: true
+ha_cluster_enable_repos_resilient_storage: false
 
 ha_cluster_cluster_present: true
 

--- a/tasks/enable-repositories/CentOS.yml
+++ b/tasks/enable-repositories/CentOS.yml
@@ -11,5 +11,8 @@
   command:
     cmd: dnf config-manager --set-enabled {{ item.id | quote }}
   loop: "{{ __ha_cluster_repos }}"
-  when: item.name not in __ha_cluster_repolist.stdout
+  when:
+    - item.id not in __ha_cluster_repolist.stdout
+    - item.name != "ResilientStorage"
+      or ha_cluster_enable_repos_resilient_storage
   changed_when: item.name not in __ha_cluster_repolist.stdout

--- a/tasks/enable-repositories/RedHat.yml
+++ b/tasks/enable-repositories/RedHat.yml
@@ -10,5 +10,8 @@
 - name: Enable RHEL repositories
   command: subscription-manager repos --enable {{ item.id | quote }}
   loop: "{{ __ha_cluster_repos }}"
-  when: item.name not in __ha_cluster_repolist.stdout
+  when:
+    - item.id not in __ha_cluster_repolist.stdout
+    - item.name != "Resilient Storage"
+      or ha_cluster_enable_repos_resilient_storage
   changed_when: item.name not in __ha_cluster_repolist.stdout

--- a/vars/CentOS_9.yml
+++ b/vars/CentOS_9.yml
@@ -1,12 +1,12 @@
 # SPDX-License-Identifier: MIT
 ---
-# Put internal variables here with CentOS 8 specific values.
+# Put internal variables here with CentOS 9 specific values.
 
 # List of repositories holding HA cluster packages.
 # id: repo ID used to enable the repo
 # name: user-friendly name of a repo used to check if the repo is enabled
 __ha_cluster_repos:
-  - id: ha
+  - id: highavailability
     name: HighAvailability
   - id: resilientstorage
     name: ResilientStorage

--- a/vars/RedHat_8.yml
+++ b/vars/RedHat_8.yml
@@ -8,3 +8,5 @@
 __ha_cluster_repos:
   - id: rhel-8-for-{{ ansible_architecture }}-highavailability-rpms
     name: High Availability
+  - id: rhel-8-for-{{ ansible_architecture }}-resilientstorage-rpms
+    name: Resilient Storage

--- a/vars/RedHat_9.yml
+++ b/vars/RedHat_9.yml
@@ -8,3 +8,5 @@
 __ha_cluster_repos:
   - id: rhel-9-for-{{ ansible_architecture }}-highavailability-rpms
     name: High Availability
+  - id: rhel-9-for-{{ ansible_architecture }}-resilientstorage-rpms
+    name: Resilient Storage


### PR DESCRIPTION
Enhancement:
add an option to enable Resilient Storage rpm repo

Reason:
to be able to install dlm and gfs2 packages

Result:
there's a new variable in the role which enables Resilient Storage rpm repo so that dlm and gfs2 packages can be installed

Issue Tracker Tickets (Jira or BZ if any):
https://issues.redhat.com/browse/RHEL-14090
