### PR TITLE
fix: cast sbd option value to string

### DIFF
--- a/templates/sbd
+++ b/templates/sbd
@@ -3,7 +3,7 @@
 
 {% macro option(ansible_name, default_value) -%}
   {%- for option in options if option.name == ansible_name -%}
-    {{ option.value }}
+    {{ option.value | string }}
   {%- else -%}
     {{ default_value }}
   {%- endfor -%}


### PR DESCRIPTION
Cause: Some versions of Ansible/Jinja have a problem with evaluating
a non-string value as a string inside of a macro.

Consequence: Ansible will give an error that a templated value
is not a string.

Fix: Cast the value to a string.

Result: Ansible correctly templates the variable with no errors.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
