### PR TITLE
test: do not use true test with select

### DIFF
--- a/tasks/shell_pcs/check-and-prepare-role-variables.yml
+++ b/tasks/shell_pcs/check-and-prepare-role-variables.yml
@@ -55,7 +55,7 @@
           [item.target is defined,
             item.target_pattern is defined,
             item.target_attribute is defined]
-          | select("true") | list | length != 1
+          | select | list | length != 1
       loop: "{{ ha_cluster_stonith_levels }}"
       run_once: true
 


### PR DESCRIPTION
Do not use `select("true")`.  This causes an error with Ansible 2.9
with Jinja 2.7 because there is no `true` test.  Instead, just rely
on the default behavior of `select` to evaluate the argument in a
boolean context.

https://jinja.palletsprojects.com/en/2.9.x/templates/#select
`If no test is specified, each object will be evaluated as a boolean.`

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
