### PR TITLE
ci: Use supported ansible-lint action; run ansible-lint against the collection

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -11,6 +11,9 @@ on:  # yamllint disable-line rule:truthy
     branches:
       - main
   workflow_dispatch:
+env:
+  LSR_ROLE2COLL_NAMESPACE: fedora
+  LSR_ROLE2COLL_NAME: linux_system_roles
 permissions:
   contents: read
 jobs:
@@ -26,18 +29,21 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Fix up role meta/main.yml namespace and name
+      - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          mm=meta/main.yml
-          if [ -f "$mm" ]; then
-            if ! grep -q '^  *namespace:' "$mm"; then
-              sed "/galaxy_info:/a\  namespace: linux_system_roles" -i "$mm"
-            fi
-            if ! grep -q '^  *role_name:' "$mm"; then
-              sed "/galaxy_info:/a\  role_name: ha_cluster" -i "$mm"
-            fi
-          fi
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.2.1"
+
+      - name: Convert role to collection format
+        run: |
+          set -euxo pipefail
+          TOXENV=collection lsr_ci_runtox
+          coll_dir=".tox/ansible_collections/$LSR_ROLE2COLL_NAMESPACE/$LSR_ROLE2COLL_NAME"
+          # ansible-lint action requires a .git directory???
+          # https://github.com/ansible/ansible-lint/blob/main/action.yml#L45
+          mkdir -p "$coll_dir/.git"
 
       - name: Run ansible-lint
-        uses: ansible-community/ansible-lint-action@v6
+        uses: ansible/ansible-lint@v6
+        with:
+          working_directory: .tox/ansible_collections/${{ env.LSR_ROLE2COLL_NAMESPACE }}/${{ env.LSR_ROLE2COLL_NAME }}

--- a/.github/workflows/ansible-managed-var-comment.yml
+++ b/.github/workflows/ansible-managed-var-comment.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.1.1"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.2.1"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-plugin-scan.yml
+++ b/.github/workflows/ansible-plugin-scan.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.1.1"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.2.1"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -33,28 +33,12 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.1.1"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.2.1"
 
       - name: Convert role to collection format
         run: |
           set -euxo pipefail
-          # Remove to avoid running ansible-test on unrelated file
-          rm -f .pandoc_template.html5
           TOXENV=collection lsr_ci_runtox
-          # copy the ignore files
-          coll_dir=".tox/ansible_collections/$LSR_ROLE2COLL_NAMESPACE/$LSR_ROLE2COLL_NAME"
-          # wokeignore:rule=sanity
-          ignore_dir="$coll_dir/tests/sanity"
-          if [ ! -d "$ignore_dir" ]; then
-            mkdir -p "$ignore_dir"
-          fi
-          # wokeignore:rule=sanity
-          for file in .sanity-ansible-ignore-*.txt; do
-            if [ -f "$file" ]; then
-              # wokeignore:rule=sanity
-              cp "$file" "$ignore_dir/${file//*.sanity-ansible-}"
-            fi
-          done
 
       - name: Run ansible-test
         uses: ansible-community/ansible-test-gh-action@release/v1

--- a/.github/workflows/python-unit-test.yml
+++ b/.github/workflows/python-unit-test.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           set -euxo pipefail
           python -m pip install --upgrade pip
-          pip install "git+https://github.com/linux-system-roles/tox-lsr@3.1.1"
+          pip install "git+https://github.com/linux-system-roles/tox-lsr@3.2.1"
           # If you have additional OS dependency packages e.g. libcairo2-dev
           # then put them in .github/config/ubuntu-requirements.txt, one
           # package per line.


### PR DESCRIPTION
The old ansible-community ansible-lint is deprecated.  There is a
new ansible-lint github action.

The latest Ansible repo gating tests run ansible-lint against
the collection format instead of against individual roles.
We have to convert the role to collection format before running
ansible-test.

This also requires tox-lsr 3.2.1 - bump other actions to use 3.2.1

Role developers can run this locally using
`tox -e collection,ansible-lint-collection`
See https://github.com/linux-system-roles/tox-lsr/pull/125

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
