### PR TITLE
feat: easily install cloud agents

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,6 +41,7 @@ variables:
   - cluster_advanced_knet_full
   - cluster_advanced_knet_implicit
   - cluster_advanced_udp_full
+  - cluster_basic_cloud_packages
   - cluster_basic_custom_fence_agents
   - cluster_basic_custom_packages
   - cluster_basic_custom_pcsd_tls_cert_role

--- a/README.md
+++ b/README.md
@@ -125,6 +125,17 @@ boolean, default: `true`
 If set to `true`, cluster services will be configured to start on boot. If set
 to `false`, cluster services will be configured not to start on boot.
 
+#### `ha_cluster_install_cloud_agents`
+
+boolean, default: `false`
+
+The role automatically installs needed HA Cluster packages. However, resource
+and fence agents for cloud environments are not installed by default on RHEL.
+If you need those to be installed, set this variable to `true`. Alternatively,
+you can specify those packages in
+[`ha_cluster_fence_agent_packages`](#ha_cluster_fence_agent_packages) and
+[`ha_cluster_extra_packages`](#ha_cluster_extra_packages) variables.
+
 #### `ha_cluster_fence_agent_packages`
 
 list of fence agent packages to install, default: fence-agents-all, fence-virt
@@ -137,8 +148,8 @@ This variable can be used to install additional packages not installed
 automatically by the role, for example custom resource agents.
 
 It is possible to specify fence agents here as well. However,
-`ha_cluster_fence_agent_packages` is preferred for that, so that its default
-value is overridden.
+[`ha_cluster_fence_agent_packages`](#ha_cluster_fence_agent_packages) is
+preferred for that, so that its default value is overridden.
 
 #### `ha_cluster_hacluster_password`
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,8 +11,8 @@ ha_cluster_cluster_present: true
 
 ha_cluster_start_on_boot: true
 
+ha_cluster_install_cloud_agents: false
 ha_cluster_extra_packages: []
-
 # Default fence agent packages are defined in respective os_family var files
 ha_cluster_fence_agent_packages:
   "{{ __ha_cluster_fence_agent_packages_default }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -57,6 +57,9 @@
           +
           ha_cluster_sbd_enabled | ternary(__ha_cluster_sbd_packages, [])
           +
+          ha_cluster_install_cloud_agents |
+            ternary(__ha_cluster_cloud_agents_packages, [])
+          +
           ha_cluster_fence_agent_packages }}"
         state: present
         use: "{{ (__ha_cluster_is_ostree | d(false)) |

--- a/tests/tests_cluster_basic_cloud_packages.yml
+++ b/tests/tests_cluster_basic_cloud_packages.yml
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Minimal cluster configuration, install cloud agents
+  hosts: all
+  vars_files: vars/main.yml
+  vars:
+    ha_cluster_cluster_name: test-cluster
+    ha_cluster_install_cloud_agents: true
+    __test_agents_rhel_8:
+      - resource-agents-aliyun
+      - resource-agents-gcp
+      - fence-agents-aliyun
+      - fence-agents-aws
+      - fence-agents-azure-arm
+      - fence-agents-gce
+    __test_agents_rhel_9:
+      - resource-agents-cloud
+      - fence-agents-aliyun
+      - fence-agents-aws
+      - fence-agents-azure-arm
+      - fence-agents-compute
+      - fence-agents-gce
+      - fence-agents-ibm-powervs
+      - fence-agents-ibm-vpc
+      - fence-agents-kubevirt
+      - fence-agents-openstack
+    __test_agents: "{{ (ansible_facts['distribution_major_version'] == '8') |
+      ternary(__test_agents_rhel_8, __test_agents_rhel_9) }}"
+    __test_eligible: "{{
+      ansible_facts['distribution'] in ['RedHat', 'CentOS'] }}"
+
+  tasks:
+    - name: Run test
+      tags: tests::verify
+      when: __test_eligible
+      block:
+        - name: Set up test environment
+          include_role:
+            name: linux-system-roles.ha_cluster
+            tasks_from: test_setup.yml
+
+        - name: Skip test on ostree systems
+          meta: end_host
+          when: __ha_cluster_is_ostree | d(false)
+
+        - name: Ensure cloud agents are not installed
+          package:
+            name: "{{ __test_agents }}"
+            state: absent
+
+        - name: Run HA Cluster role
+          include_role:
+            name: linux-system-roles.ha_cluster
+            public: true
+
+        - name: Get packages status
+          package_facts:
+
+        - name: Check installed packages
+          assert:
+            that:
+              - "item in ansible_facts.packages"
+          loop: "{{ __test_agents }}"
+
+        - name: Check cluster status
+          include_tasks: tasks/assert_cluster_running.yml
+
+    - name: Message
+      debug:
+        msg: This test is RHEL / CentOS specific
+      when: not __test_eligible

--- a/vars/CentOS_8.yml
+++ b/vars/CentOS_8.yml
@@ -10,3 +10,11 @@ __ha_cluster_repos:
     name: HighAvailability
   - id: resilientstorage
     name: ResilientStorage
+
+__ha_cluster_cloud_agents_packages:
+  - resource-agents-aliyun
+  - resource-agents-gcp
+  - fence-agents-aliyun
+  - fence-agents-aws
+  - fence-agents-azure-arm
+  - fence-agents-gce

--- a/vars/CentOS_9.yml
+++ b/vars/CentOS_9.yml
@@ -10,3 +10,15 @@ __ha_cluster_repos:
     name: HighAvailability
   - id: resilientstorage
     name: ResilientStorage
+
+__ha_cluster_cloud_agents_packages:
+  - resource-agents-cloud
+  - fence-agents-aliyun
+  - fence-agents-aws
+  - fence-agents-azure-arm
+  - fence-agents-compute
+  - fence-agents-gce
+  - fence-agents-ibm-powervs
+  - fence-agents-ibm-vpc
+  - fence-agents-kubevirt
+  - fence-agents-openstack

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: MIT
+---
+# Put internal variables here with Fedora specific values.
+__ha_cluster_cloud_agents_packages: []

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -23,6 +23,8 @@ __ha_cluster_fullstack_node_packages:
   - pacemaker
   - openssl  # used in the role for generating preshared keys
 
+__ha_cluster_cloud_agents_packages: []
+
 __ha_cluster_qdevice_node_packages:
   - corosync-qdevice
   # dependencies of a script to set up qdevice certificates

--- a/vars/RedHat_8.yml
+++ b/vars/RedHat_8.yml
@@ -10,3 +10,11 @@ __ha_cluster_repos:
     name: High Availability
   - id: rhel-8-for-{{ ansible_architecture }}-resilientstorage-rpms
     name: Resilient Storage
+
+__ha_cluster_cloud_agents_packages:
+  - resource-agents-aliyun
+  - resource-agents-gcp
+  - fence-agents-aliyun
+  - fence-agents-aws
+  - fence-agents-azure-arm
+  - fence-agents-gce

--- a/vars/RedHat_9.yml
+++ b/vars/RedHat_9.yml
@@ -10,3 +10,15 @@ __ha_cluster_repos:
     name: High Availability
   - id: rhel-9-for-{{ ansible_architecture }}-resilientstorage-rpms
     name: Resilient Storage
+
+__ha_cluster_cloud_agents_packages:
+  - resource-agents-cloud
+  - fence-agents-aliyun
+  - fence-agents-aws
+  - fence-agents-azure-arm
+  - fence-agents-compute
+  - fence-agents-gce
+  - fence-agents-ibm-powervs
+  - fence-agents-ibm-vpc
+  - fence-agents-kubevirt
+  - fence-agents-openstack

--- a/vars/Suse.yml
+++ b/vars/Suse.yml
@@ -22,6 +22,8 @@ __ha_cluster_role_essential_packages:
 
 __ha_cluster_fullstack_node_packages: []
 
+__ha_cluster_cloud_agents_packages: []
+
 __ha_cluster_qdevice_node_packages:
   - corosync-qdevice
 


### PR DESCRIPTION
Enhancement:
Make it easier to install agents for cloud environments.

Reason:
The agents are not installed by default. Even though users can install them by other means, we want to provide a variable to install them easily.

Result:
Setting `ha_cluster_install_cloud_agents` variable to `true` installs cloud agents.

Issue Tracker Tickets (Jira or BZ if any):
[RHEL-27186](https://issues.redhat.com/browse/RHEL-27186)
#185 