### PR TITLE
feat: Add support for utilization

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,7 +580,7 @@ The items are as follows:
 * `attributes` (optional) - List of sets of Pacemaker node attributes for the
   node. Currently, only one set is supported, so the first set is used and the
   rest are ignored.
-* `utilization` (optional) - List of sets of the node's utilization.The field
+* `utilization` (optional) - List of sets of the node's utilization. The field
   `value` must be an integer. Currently, only one set is supported, so the first
   set is used and the rest are ignored.
 
@@ -2201,8 +2201,6 @@ Note that you cannot run a quorum device on a cluster node.
 ```yaml
 - hosts: node1 node2
   vars:
-    ha_cluster_manage_firewall: true
-    ha_cluster_manage_selinux: true
     ha_cluster_cluster_name: my-new-cluster
     ha_cluster_hacluster_password: password
     # For utilization to have an effect, the `placement-strategy` property

--- a/examples/utilization.yml
+++ b/examples/utilization.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 ---
-- name: Example ha_cluster role invocation - node attributes definition
+- name: Example ha_cluster role invocation - utilization definition
   hosts: node1 node2
   vars:
     ha_cluster_manage_firewall: true

--- a/examples/utilization.yml
+++ b/examples/utilization.yml
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Example ha_cluster role invocation - node attributes definition
+  hosts: node1 node2
+  vars:
+    ha_cluster_manage_firewall: true
+    ha_cluster_manage_selinux: true
+    ha_cluster_cluster_name: my-new-cluster
+    ha_cluster_hacluster_password: password
+    # For utilization to have an effect, the `placement-strategy` property
+    # must be set and its value must be different from the value `default`.
+    ha_cluster_cluster_properties:
+      - attrs:
+          - name: placement-strategy
+            value: utilization
+    ha_cluster_node_options:
+      - node_name: node1
+        utilization:
+          - attrs:
+              - name: utilization1
+                value: 1
+              - name: utilization2
+                value: 2
+      - node_name: node2
+        utilization:
+          - attrs:
+              - name: utilization1
+                value: 3
+              - name: utilization2
+                value: 4
+    ha_cluster_resource_primitives:
+      - id: resource1
+        # wokeignore:rule=dummy
+        agent: 'ocf:pacemaker:Dummy'
+        utilization:
+          - attrs:
+              - name: utilization1
+                value: 2
+              - name: utilization2
+                value: 3
+
+
+  roles:
+    - linux-system-roles.ha_cluster

--- a/tasks/shell_pcs/create-and-push-cib.yml
+++ b/tasks/shell_pcs/create-and-push-cib.yml
@@ -103,6 +103,16 @@
       loop_control:
         loop_var: node_options
 
+    ## Node utilization
+    - name: Configure node utilization
+      include_tasks: pcs-node-utilization.yml
+      loop: >-
+        {{
+          ha_cluster_node_options | selectattr('utilization', 'defined') | list
+        }}
+      loop_control:
+        loop_var: node_options
+
     ## Resource and operation defaults
     # RHEL 8.3, which is the oldest version supported by the role, supports
     # multiple sets of resources and resources operations defaults. Therefore,

--- a/tasks/shell_pcs/pcs-cib-resource-primitive.yml
+++ b/tasks/shell_pcs/pcs-cib-resource-primitive.yml
@@ -58,7 +58,7 @@
   check_mode: false
   changed_when: not ansible_check_mode
 
-- name: Configure utilization for resource {{ resource.id }}
+- name: Configure utilization for resource primitive {{ resource.id }}
   command:
     # Multiple sets of utilization per node are not supported by pcs (and
     # therefore the role) as of yet

--- a/tasks/shell_pcs/pcs-cib-resource-primitive.yml
+++ b/tasks/shell_pcs/pcs-cib-resource-primitive.yml
@@ -57,3 +57,22 @@
   # the cluster.
   check_mode: false
   changed_when: not ansible_check_mode
+
+- name: Configure utilization for resource {{ resource.id }}
+  command:
+    # Multiple sets of utilization per node are not supported by pcs (and
+    # therefore the role) as of yet
+    cmd: >
+      pcs -f {{ __ha_cluster_tempfile_cib_xml.path | quote }}
+      -- resource utilization {{ resource.id | quote }}
+      {% if resource.utilization | d([]) %}
+        {% for attr in resource.utilization[0].attrs %}
+          {{ attr.name | quote }}={{ attr.value | quote }}
+        {% endfor %}
+      {% endif %}
+  # We always need to create CIB to see whether it's the same as what is
+  # already present in the cluster. However, we don't want to report it as a
+  # change since the only thing which matters is pushing the resulting CIB to
+  # the cluster.
+  check_mode: false
+  changed_when: not ansible_check_mode

--- a/tasks/shell_pcs/pcs-cib-resource-primitive.yml
+++ b/tasks/shell_pcs/pcs-cib-resource-primitive.yml
@@ -66,7 +66,7 @@
       pcs -f {{ __ha_cluster_tempfile_cib_xml.path | quote }}
       -- resource utilization {{ resource.id | quote }}
       {% if resource.utilization | d([]) %}
-        {% for attr in resource.utilization[0].attrs %}
+        {% for attr in resource.utilization[0].attrs | d([]) %}
           {{ attr.name | quote }}={{ attr.value | quote }}
         {% endfor %}
       {% endif %}

--- a/tasks/shell_pcs/pcs-node-utilization.yml
+++ b/tasks/shell_pcs/pcs-node-utilization.yml
@@ -7,7 +7,7 @@
     cmd: >
       pcs -f {{ __ha_cluster_tempfile_cib_xml.path | quote }}
       -- node utilization {{ node_options.node_name | quote }}
-      {% for attr in node_options.utilization[0].attrs %}
+      {% for attr in node_options.utilization[0].attrs | d([]) %}
         {{ attr.name | quote }}={{ attr.value | quote }}
       {% endfor %}
   # We always need to create CIB to see whether it's the same as what is

--- a/tasks/shell_pcs/pcs-node-utilization.yml
+++ b/tasks/shell_pcs/pcs-node-utilization.yml
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Configure utilizations for node {{ node_options.node_name }}
+  command:
+    # Multiple sets of utilization per node are not supported by pcs (and
+    # therefore the role) as of yet
+    cmd: >
+      pcs -f {{ __ha_cluster_tempfile_cib_xml.path | quote }}
+      -- node utilization {{ node_options.node_name | quote }}
+      {% for attr in node_options.utilization[0].attrs %}
+        {{ attr.name | quote }}={{ attr.value | quote }}
+      {% endfor %}
+  # We always need to create CIB to see whether it's the same as what is
+  # already present in the cluster. However, we don't want to report it as a
+  # change since the only thing which matters is pushing the resulting CIB to
+  # the cluster.
+  check_mode: false
+  changed_when: not ansible_check_mode

--- a/tests/tests_cib_utilization.yml
+++ b/tests/tests_cib_utilization.yml
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Configure utilization
+  hosts: all
+  vars_files: vars/main.yml
+
+  tasks:
+    - name: Run test
+      tags: tests::verify
+      block:
+        - name: Set up test environment
+          include_role:
+            name: linux-system-roles.ha_cluster
+            tasks_from: test_setup.yml
+
+        - name: Find first node name
+          set_fact:
+            __test_first_node: "{{
+                (ansible_play_hosts_all | length == 1)
+                | ternary('localhost', ansible_play_hosts[0]) }}"
+
+        - name: Run HA Cluster role
+          include_role:
+            name: linux-system-roles.ha_cluster
+            public: true
+          vars:
+            ha_cluster_cluster_name: test-cluster
+            ha_cluster_manage_firewall: true
+            ha_cluster_manage_selinux: true
+            # Property placement-strategy must be set accordingly. When not set,
+            # there is an extra warning in the `pcs node|resource utilization`
+            # result.
+            ha_cluster_cluster_properties:
+              - attrs:
+                  - name: placement-strategy
+                    value: utilization
+            ha_cluster_node_options:
+              - node_name: "{{ __test_first_node }}"
+                utilization:
+                  - attrs:
+                      - name: cpu
+                        value: 2
+                      - name: memory
+                        value: 4096
+            ha_cluster_resource_primitives:
+              - id: resource1
+                # wokeignore:rule=dummy
+                agent: 'ocf:pacemaker:Dummy'
+                utilization:
+                  - attrs:
+                      - name: cpu
+                        value: 1
+                  - attrs:
+                      - name: memory
+                        value: 1024
+              # Resource without utilization to ensure that they are optional.
+              - id: resource2
+                # wokeignore:rule=dummy
+                agent: 'ocf:pacemaker:Dummy'
+
+        - name: Verify node utilization
+          vars:
+            __test_expected_lines:
+              - "Node Utilization:"
+              - " {{ __test_first_node }}: cpu=2 memory=4096"
+          block:
+            - name: Fetch node utilization configuration from the cluster
+              command:
+                cmd: pcs node utilization
+              register: __test_pcs_node_utilization_config
+              changed_when: false
+
+            - name: Print real node utilization configuration
+              debug:
+                var: __test_pcs_node_utilization_config
+
+            - name: Print expected node utilization configuration
+              debug:
+                var: __test_expected_lines | list
+
+            - name: Check node utilization configuration
+              assert:
+                that:
+                  - __test_pcs_node_utilization_config.stdout_lines
+                    == __test_expected_lines | list
+
+        - name: Verify resource utilization
+          vars:
+            __test_expected_lines:
+              - "Resource Utilization:"
+              - " resource1: cpu=1"
+          block:
+            - name: Fetch resource utilization configuration from the cluster
+              command:
+                cmd: pcs resource utilization
+              register: __test_pcs_resource_utilization_config
+              changed_when: false
+
+            - name: Print real resource utilization configuration
+              debug:
+                var: __test_pcs_resource_utilization_config
+
+            - name: Print expected resource utilization configuration
+              debug:
+                var: __test_expected_lines | list
+
+            - name: Check resource utilization configuration
+              assert:
+                that:
+                  - __test_pcs_resource_utilization_config.stdout_lines
+                    == __test_expected_lines | list
+
+        - name: Check firewall and selinux state
+          include_tasks: tasks/check_firewall_selinux.yml


### PR DESCRIPTION
Enhancement:
Add support for configuring utilization attributes.

Reason:
This is necessary so that user can configure utilization attributes for node and primitive resource..

Result:
It is now possible to configure utilization attributes  using the role.

Issue Tracker Tickets (Jira or BZ if any):
https://issues.redhat.com/browse/RHEL-33532