### PR TITLE
ci: tox-lsr 3.4.0 - fix py27 tests; move other checks to py310

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.3.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.4.0"
 
       - name: Convert role to collection format
         run: |

--- a/.github/workflows/ansible-managed-var-comment.yml
+++ b/.github/workflows/ansible-managed-var-comment.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.3.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.4.0"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-plugin-scan.yml
+++ b/.github/workflows/ansible-plugin-scan.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.3.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.4.0"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.3.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.4.0"
 
       - name: Convert role to collection format
         run: |

--- a/.github/workflows/python-unit-test.yml
+++ b/.github/workflows/python-unit-test.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           set -euxo pipefail
           python -m pip install --upgrade pip
-          pip install "git+https://github.com/linux-system-roles/tox-lsr@3.3.0"
+          pip install "git+https://github.com/linux-system-roles/tox-lsr@3.4.0"
           # If you have additional OS dependency packages e.g. libcairo2-dev
           # then put them in .github/config/ubuntu-requirements.txt, one
           # package per line.
@@ -80,11 +80,8 @@ jobs:
           toxenvs="py${toxpyver}"
           # NOTE: The use of flake8, pylint, black with specific
           # python envs is arbitrary and must be changed in tox-lsr
-          # We really should either do those checks using the latest
-          # version of python, or in every version of python
           case "$toxpyver" in
-          27) toxenvs="${toxenvs},coveralls,flake8,pylint" ;;
-          36) toxenvs="${toxenvs},coveralls,black" ;;
+          310) toxenvs="${toxenvs},coveralls,flake8,pylint,black" ;;
           *) toxenvs="${toxenvs},coveralls" ;;
           esac
           TOXENV="$toxenvs" lsr_ci_runtox

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: MIT
 ---
-extends: default
 ignore: |
   /.tox/

--- a/tasks/shell_pcs/cluster-setup-corosync.yml
+++ b/tasks/shell_pcs/cluster-setup-corosync.yml
@@ -29,7 +29,7 @@
     dest: /etc/corosync/corosync.conf
     owner: root
     group: root
-    mode: 0644
+    mode: "0644"
   register: __ha_cluster_distribute_corosync_conf
   when: __ha_cluster_data_corosync_conf is defined
 

--- a/tasks/shell_pcs/cluster-setup-keys.yml
+++ b/tasks/shell_pcs/cluster-setup-keys.yml
@@ -14,7 +14,7 @@
     dest: /etc/corosync/authkey
     owner: root
     group: root
-    mode: 0400
+    mode: "0400"
   register: __ha_cluster_distribute_corosync_authkey
 
 - name: Get pacemaker authkey
@@ -31,7 +31,7 @@
     dest: /etc/pacemaker/authkey
     owner: hacluster
     group: haclient
-    mode: 0400
+    mode: "0400"
   register: __ha_cluster_distribute_pacemaker_authkey
 
 - name: Remove qdevice certificates [CLI]

--- a/tasks/shell_pcs/configure-shell.yml
+++ b/tasks/shell_pcs/configure-shell.yml
@@ -67,14 +67,14 @@
         dest: /var/lib/pcsd/pcsd.key
         owner: root
         group: root
-        mode: 0600
+        mode: "0600"
     - name: Distribute pcsd TLS certificate
       copy:
         src: "{{ ha_cluster_pcsd_public_key_src }}"
         dest: /var/lib/pcsd/pcsd.crt
         owner: root
         group: root
-        mode: 0600
+        mode: "0600"
 
 - name: Distribute pcs_settings.conf
   template:
@@ -82,7 +82,7 @@
     dest: /var/lib/pcsd/pcs_settings.conf
     owner: root
     group: root
-    mode: 0644
+    mode: "0644"
     trim_blocks: false
 
 - name: Start pcsd with updated config files and configure it to start on boot

--- a/tasks/shell_pcs/create-and-push-cib.yml
+++ b/tasks/shell_pcs/create-and-push-cib.yml
@@ -36,7 +36,7 @@
     dest: "{{ item }}"
     owner: root
     group: root
-    mode: 0600
+    mode: "0600"
   loop:
     - "{{ __ha_cluster_tempfile_cib_xml.path }}"
     - "{{ __ha_cluster_tempfile_original_cib_xml.path }}"
@@ -276,7 +276,7 @@
     dest: "{{ __ha_cluster_tempfile_cib_diff.path }}"
     owner: root
     group: root
-    mode: 0600
+    mode: "0600"
   check_mode: false
   changed_when: not ansible_check_mode
   when: __ha_cluster_cib_diff.rc == 1

--- a/tasks/shell_pcs/sbd.yml
+++ b/tasks/shell_pcs/sbd.yml
@@ -11,7 +11,7 @@
               lineinfile:
                 path: "/etc/modprobe.d/{{ item }}.conf"
                 create: true
-                mode: 0644
+                mode: "0644"
                 # wokeignore:rule=blacklist
                 regexp: "^(options|blacklist) {{ item }}"
                 # wokeignore:rule=blacklist
@@ -35,7 +35,7 @@
               lineinfile:
                 path: "/etc/modules-load.d/{{ item }}.conf"
                 create: true
-                mode: 0644
+                mode: "0644"
                 regexp: "^{{ item }}"
                 line: "{{ item }}"
                 state: present
@@ -95,7 +95,7 @@
         dest: /etc/sysconfig/sbd
         owner: root
         group: root
-        mode: 0644
+        mode: "0644"
       vars:
         options: "{{ ha_cluster_sbd_options | d([]) }}"
         node_name: "{{ __ha_cluster_node_name }}"
@@ -119,7 +119,7 @@
             state: directory
             owner: root
             group: root
-            mode: 0755
+            mode: "0755"
 
         - name: Override start timeout for SBD
           template:
@@ -127,7 +127,7 @@
             dest: /etc/systemd/system/sbd.service.d/override-timeout.conf
             owner: root
             group: root
-            mode: 0644
+            mode: "0644"
           vars:
             # Make sure the timeout is at least the default 90 seconds.
             # The intent is to make the timeout longer if needed, not shorter.
@@ -169,7 +169,7 @@
         state: file
         owner: hacluster
         group: haclient
-        mode: 0600
+        mode: "0600"
       when:
         - not pacemaker_running
 

--- a/tests/tasks/fixture_psks.yml
+++ b/tests/tasks/fixture_psks.yml
@@ -35,16 +35,16 @@
       copy:
         content: "{{ lookup('pipe', 'openssl rand -base64 256') | b64decode }}"
         dest: "{{ __test_corosync_key_path }}"
-        mode: 0400
+        mode: "0400"
 
     - name: Generate pacemaker key
       copy:
         content: "{{ lookup('pipe', 'openssl rand -base64 256') | b64decode }}"
         dest: "{{ __test_pacemaker_key_path }}"
-        mode: 0400
+        mode: "0400"
 
     - name: Generate fence_xvm key
       copy:
         content: "{{ lookup('pipe', 'openssl rand -base64 512') | b64decode }}"
         dest: "{{ __test_fence_xvm_key_path }}"
-        mode: 0400
+        mode: "0400"

--- a/tests/tasks/qnetd_backup_restore.yml
+++ b/tests/tasks/qnetd_backup_restore.yml
@@ -7,7 +7,7 @@
       file:
         path: /etc/corosync/qnetd_backup
         state: directory
-        mode: 0700
+        mode: "0700"
 
     # Ansible copy doesn't support 'mode: preserve' with 'remote_src: true'
     - name: Back up qnetd settings

--- a/tests/tests_cluster_basic_existing_psks.yml
+++ b/tests/tests_cluster_basic_existing_psks.yml
@@ -39,7 +39,7 @@
             state: directory
             owner: root
             group: root
-            mode: 0755
+            mode: "0755"
           loop:
             - /etc/corosync
             - /etc/pacemaker
@@ -52,7 +52,7 @@
             dest: /etc/corosync/authkey
             owner: root
             group: root
-            mode: 0400
+            mode: "0400"
 
         - name: Ensure pacemaker key is present
           copy:
@@ -60,7 +60,7 @@
             dest: /etc/pacemaker/authkey
             owner: root
             group: root
-            mode: 0400
+            mode: "0400"
 
         - name: Ensure fence-virt key is present
           copy:
@@ -68,7 +68,7 @@
             dest: /etc/cluster/fence_xvm.key
             owner: root
             group: root
-            mode: 0400
+            mode: "0400"
           when: __test_fence_virt_supported
 
         - name: Distribute pcsd TLS private key
@@ -77,7 +77,7 @@
             dest: /var/lib/pcsd/pcsd.key
             owner: root
             group: root
-            mode: 0600
+            mode: "0600"
 
         - name: Distribute pcsd TLS certificate
           copy:
@@ -85,7 +85,7 @@
             dest: /var/lib/pcsd/pcsd.crt
             owner: root
             group: root
-            mode: 0600
+            mode: "0600"
 
         - name: Get corosync key hash
           stat:

--- a/tests/tests_cluster_basic_new_psks.yml
+++ b/tests/tests_cluster_basic_new_psks.yml
@@ -43,7 +43,7 @@
             state: directory
             owner: root
             group: root
-            mode: 0755
+            mode: "0755"
           loop:
             - /etc/pacemaker
             - /var/lib/pcsd
@@ -54,7 +54,7 @@
             dest: /etc/pacemaker/authkey
             owner: root
             group: root
-            mode: 0400
+            mode: "0400"
 
         - name: Ensure fence-virt key is not present
           file:
@@ -68,7 +68,7 @@
             dest: /var/lib/pcsd/pcsd.key
             owner: root
             group: root
-            mode: 0600
+            mode: "0600"
 
         - name: Distribute pcsd TLS certificate
           copy:
@@ -76,7 +76,7 @@
             dest: /var/lib/pcsd/pcsd.crt
             owner: root
             group: root
-            mode: 0600
+            mode: "0600"
 
         - name: Get corosync key hash
           stat:

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,9 @@ lsr_enable = true
 [lsr_ansible-lint]
 configfile = {toxinidir}/.ansible-lint
 
+[lsr_black]
+configfile = {toxinidir}/pyproject.toml
+
 # NOTE: In order to run python unit tests locally, you will need
 # to comment sitepackages=True then build and install the correct
 # version of pcs in the testenv.  See .github/workflows/python-unit-test.yml
@@ -13,3 +16,6 @@ configfile = {toxinidir}/.ansible-lint
 # ansible-lint-collection: failed with ansible-lint is not allowed, use allowlist_externals to allow it
 [testenv]
 sitepackages=True
+setenv =
+    RUN_PYTEST_SETUP_MODULE_UTILS = true
+    RUN_PYLINT_SETUP_MODULE_UTILS = true


### PR DESCRIPTION
The latest version of virtualenv does not support creating
python 2.7 virtualenvs.  Change our CI tests to restrict the version
of virtualenv<20.22.0 and tox<4.15 for py27 environments

Move pylint, flake8, and black checks to the py310 environment
which is currently supported by ansible-core 2.17 and its related
checkers such as ansible-lint and ansible-test

pylint now uses ansible-core 2.17 and restricts the version of
pylint to 3.1.0 which is the version used by ansible-test 2.17

Remove `extends: default` for .yamllint.yml.  The latest version
of ansible-lint will automatically incorporate local yamllint
settings unless there is an `extends:`.

The above changes require some fixes to the role code.

For more information, see
https://github.com/linux-system-roles/tox-lsr/pull/168
and
https://github.com/linux-system-roles/tox-lsr/pull/170

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
