### PR TITLE
ci: fix Python discovery with Ansible 2.17+

### DIFF
--- a/.gitlab-ci-tier1.yml.j2
+++ b/.gitlab-ci-tier1.yml.j2
@@ -10,19 +10,25 @@
 # https://github.com/ansible/awx/issues/14496#issuecomment-1743711473
 .run_test:
   before_script:
-    - source "${PYENV_ROOT}/bin/activate"
-    - python --version
-  script:
     - echo "$BASE_IMAGE_NAME"
     - echo "$TEST_NAME"
-    - if [ "x${BASE_IMAGE_NAME}" == "xLsrRhel8OldestAnsibleCurrent" ]; then GALAXY_SERVER="https://old-galaxy.ansible.com"; fi
+    - source "${PYENV_ROOT}/bin/activate"
+    - python --version
+    - ansible --version
+  script:
+    - ([ "x${BASE_IMAGE_NAME}" == "xLsrRhel8OldestAnsibleCurrent" ]) && GALAXY_SERVER="https://old-galaxy.ansible.com" || GALAXY_SERVER=""
     - echo "$GALAXY_SERVER"
     - ansible-galaxy collection install -vvv "--server=${GALAXY_SERVER}" -r ./meta/collection-requirements.yml
     - varsparams=""
+    # Use ansible-2.16-like Python in ansible 2.17+ (RHEL8 supports ansible < 2.17 only)
+    # See https://github.com/linux-system-roles/ha_cluster/pull/205#issuecomment-2141431543
+    - (echo "x${BASE_IMAGE_NAME}" | grep -Eq '^xLsrRhel9.+AnsibleCurrent$') && varsparams+=" -e ansible_python_interpreter=/usr/bin/python3"
+    - echo "$varsparams"
     - TEST_FILE_NAME="tests_${TEST_NAME}.yml"
     - echo "$TEST_FILE_NAME"
-    - if ! grep "$TEST_FILE_NAME" tests/no-vault-variables.txt; then varsparams="-e @tests/vars/vault-variables.yml"; fi
-    - ansible-playbook -v -i localhost, --vault-password-file tests/vault_pwd $varsparams "tests/${TEST_FILE_NAME}"
+    - (grep "$TEST_FILE_NAME" tests/no-vault-variables.txt) || varsparams+=" -e @tests/vars/vault-variables.yml"
+    - echo "$varsparams"
+    - ansible-playbook -v -i localhost, -c local --vault-password-file tests/vault_pwd $varsparams "tests/${TEST_FILE_NAME}"
   after_script:
     - mkdir var_log
     - journalctl -x > var_log/journal


### PR DESCRIPTION
Fix Python discovery with Ansible 2.17+ in gitlab CI. Also, make the gitlab CI script more verbose and replace if-then-else with && or ||.