### PR TITLE
docs: fix sbd_devices documentation and examples

### DIFF
--- a/examples/sbd.yml
+++ b/examples/sbd.yml
@@ -3,6 +3,13 @@
 - name: Example ha_cluster role invocation - cluster with SBD
   hosts: node1 node2
   vars:
+    my_sbd_devices:
+      # This variable is not used by the role.
+      # It's purpose is to define SBD devices once so they don't need
+      # to be repeated several times in the role variables.
+      - /dev/disk/by-id/000001
+      - /dev/disk/by-id/000002
+      - /dev/disk/by-id/000003
     ha_cluster_manage_firewall: true
     ha_cluster_manage_selinux: true
     ha_cluster_cluster_name: my-new-cluster
@@ -24,20 +31,14 @@
         sbd_watchdog_modules_blocklist:
           - ipmi_watchdog
         sbd_watchdog: /dev/watchdog1
-        sbd_devices:
-          - /dev/vdx
-          - /dev/vdy
-          - /dev/vdz
+        sbd_devices: "{{ my_sbd_devices }}"
       - node_name: node2
         sbd_watchdog_modules:
           - iTCO_wdt
         sbd_watchdog_modules_blocklist:
           - ipmi_watchdog
         sbd_watchdog: /dev/watchdog1
-        sbd_devices:
-          - /dev/vdx
-          - /dev/vdy
-          - /dev/vdz
+        sbd_devices: "{{ my_sbd_devices }}"
     # Best practice for setting SBD timeouts:
     # watchdog-timeout * 2 = msgwait-timeout (set automatically)
     # msgwait-timeout * 1.2 = stonith-timeout
@@ -50,9 +51,8 @@
         agent: 'stonith:fence_sbd'
         instance_attrs:
           - attrs:
-              # taken from host_vars
               - name: devices
-                value: "{{ ha_cluster.sbd_devices | join(',') }}"
+                value: "{{ my_sbd_devices | join(',') }}"
               - name: pcmk_delay_base
                 value: 30
 


### PR DESCRIPTION
Enhancement:
Fix documentation and examples regarding configuring SBD devices in fence_sbd agent.

Reason:
`ha_cluster.sbd_devices` variable is used in examples even though it isn't defined. In other example the variable is defined, but its content depends on the node the task is executed on, which is bad practice for configuring sbd.

Result:
Examples and documentation are updated to show a recommended way of configuring SBD devices.

Issue Tracker Tickets (Jira or BZ if any):
https://issues.redhat.com/browse/RHELDOCS-18172