### PR TITLE
fix: openssl is now required for password

### DIFF
--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -15,13 +15,13 @@ __ha_cluster_role_essential_packages:
   # even if qnetd is not being configured, it is needed for removing qnetd
   # configuration
   - corosync-qnetd
+  - openssl
 
 __ha_cluster_fullstack_node_packages:
   - corosync
   - libknet1-plugins-all
   - resource-agents
   - pacemaker
-  - openssl  # used in the role for generating preshared keys
 
 __ha_cluster_cloud_agents_packages: []
 

--- a/vars/Suse.yml
+++ b/vars/Suse.yml
@@ -19,6 +19,7 @@ __ha_cluster_role_essential_packages:
   - 'socat'
   - 'libxml2-tools'
   - 'rsyslog'
+  - 'openssl'
 
 __ha_cluster_fullstack_node_packages: []
 


### PR DESCRIPTION
openssl is now used to generate passwords, so make it
a required basic package.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
