### PR TITLE
feat: crmsh 4.6.0 support and stonith-enabled workflow update

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ An Ansible role for managing High Availability Clustering.
 
 * Compatible OS
   * RHEL 8.3+, Fedora 31+
-  * SLES 15 SP5+ with HA extension, SLES4SAP 15 SP5+
+  * SUSE Linux Enterprise Server 15 with HA extension
+  * SUSE Linux Enterprise Server for SAP Applications 15
 * Systems running RHEL are expected to be registered and have High-Availability
   repositories accessible, and ResilientStorage repositories accessible if using
   `ha_cluster_enable_repos_resilient_storage`
@@ -152,6 +153,13 @@ automatically by the role, for example custom resource agents.
 It is possible to specify fence agents here as well. However,
 [`ha_cluster_fence_agent_packages`](#ha_cluster_fence_agent_packages) is
 preferred for that, so that its default value is overridden.
+
+#### `ha_cluster_use_latest_packages`
+
+boolean, default: `false`
+
+If set to `true`, all packages will be installed with latest version.</br>
+If set to `false`, existing packages will not be updated.
 
 #### `ha_cluster_hacluster_password`
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ preferred for that, so that its default value is overridden.
 
 boolean, default: `false`
 
-If set to `true`, all packages will be installed with latest version.</br>
+If set to `true`, all packages will be installed with latest version.
 If set to `false`, existing packages will not be updated.
 
 #### `ha_cluster_hacluster_password`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,6 +16,7 @@ ha_cluster_extra_packages: []
 # Default fence agent packages are defined in respective os_family var files
 ha_cluster_fence_agent_packages:
   "{{ __ha_cluster_fence_agent_packages_default }}"
+ha_cluster_use_latest_packages: false
 
 ha_cluster_hacluster_password: ""
 ha_cluster_regenerate_keys: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,7 +14,7 @@
       __ha_cluster_role_essential_packages
       +
       ha_cluster_extra_packages }}"
-    state: present
+    state: latest
     use: "{{ (__ha_cluster_is_ostree | d(false)) |
              ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
 
@@ -73,7 +73,7 @@
             ternary(__ha_cluster_cloud_agents_packages, [])
           +
           ha_cluster_fence_agent_packages }}"
-        state: present
+        state: latest
         use: "{{ (__ha_cluster_is_ostree | d(false)) |
                  ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,7 +14,7 @@
       __ha_cluster_role_essential_packages
       +
       ha_cluster_extra_packages }}"
-    state: latest
+    state: "{{ 'latest' if ha_cluster_use_latest_packages else 'present' }}"
     use: "{{ (__ha_cluster_is_ostree | d(false)) |
              ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
 
@@ -73,7 +73,7 @@
             ternary(__ha_cluster_cloud_agents_packages, [])
           +
           ha_cluster_fence_agent_packages }}"
-        state: latest
+        state: "{{ 'latest' if ha_cluster_use_latest_packages else 'present' }}"
         use: "{{ (__ha_cluster_is_ostree | d(false)) |
                  ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
 

--- a/tasks/shell_crmsh/create-and-push-cib.yml
+++ b/tasks/shell_crmsh/create-and-push-cib.yml
@@ -27,23 +27,28 @@
   check_mode: false
   changed_when: not ansible_check_mode
 
-# Maintenance mode is required, because CIB version changes with cluster
-# status changes, resulting in shadow CIB outdated and unable to patch.
-# Sleep is implemented to ensure that cluster have enough time to freeze
-# to ensure CIB export consistency.
 # Meta-attrs is-managed will conflict with maintenance mode as well as
 # individual resource maintenance attributes. Expect will skip their deletion.
+# - name: Put cluster in maintenance mode to freeze cib changes
+#   ansible.builtin.expect:
+#     command: crm --force configure property maintenance-mode=true
+#     responses:
+#       ".*is-managed.*": "n"
+#       ".*already.*": "n"
+#   run_once: true  # noqa: run_once[task]
+#   check_mode: false
+#   changed_when: true
+
+# Maintenance mode is required, because CIB version changes with cluster
+# status changes, resulting in shadow CIB outdated and unable to patch.
 - name: Put cluster in maintenance mode to freeze cib changes
-  ansible.builtin.expect:
-    command: crm configure property maintenance-mode=true
-    responses:
-      ".*is-managed.*": "n"
-      ".*already.*": "n"
+  ansible.builtin.command:
+    cmd: crm --force configure property maintenance-mode=true
   run_once: true  # noqa: run_once[task]
   check_mode: false
   changed_when: true
 
-- name: Verify that maintenace-mode is true
+- name: Verify that maintenance-mode is true
   ansible.builtin.command:
     cmd: crm status
   register: __ha_cluster_crm_status_maint
@@ -116,12 +121,16 @@
 # Build the new CIB
 - name: Build the new CIB
   block:
-    ## Cluster properties
-    - name: Configure cluster properties
-      ansible.builtin.include_tasks: crm-cluster-properties.yml
-      vars:
-        properties_set: "{{ ha_cluster_cluster_properties[0] }}"
-      when: ha_cluster_cluster_properties[0].attrs | d([])
+    ## Ensure that stonith is disabled before executing crm configure.
+    ## This is usually disabled by running crm init.
+    ## Executing crm configure without stonith results in "config not valid".
+    - name: Set property stonith-enabled to false
+      ansible.builtin.command:
+        cmd: >-
+          crm -c {{ __ha_cluster_crm_shadow }}
+          configure property stonith-enabled=false
+      check_mode: false
+      changed_when: not ansible_check_mode
 
     ## Resource defaults
     - name: Configure resource defaults
@@ -229,6 +238,38 @@
         index_var: constraint_index
         loop_var: constraint
 
+    ## Cluster properties
+    - name: Configure cluster properties
+      ansible.builtin.include_tasks: crm-cluster-properties.yml
+      vars:
+        properties_set: "{{ ha_cluster_cluster_properties[0] }}"
+      when: ha_cluster_cluster_properties[0].attrs | d([])
+
+    # Verify CIB to ensure that there are no errors before applying.
+    - name: Verify shadow CIB
+      ansible.builtin.command:
+        cmd: >-
+          crm_verify -V -x
+          /var/lib/pacemaker/cib/shadow.{{ __ha_cluster_crm_shadow }}
+      register: __ha_cluster_crm_verify
+      ignore_errors: true
+      check_mode: false
+      changed_when: false
+
+    ## Fail execution if shadow CIB is not valid.
+    ## Example: No STONITH resources were defined while stonith-enabled is true
+    - name: Fail if shadow CIB is invalid
+      ansible.builtin.fail:
+        msg:
+          - "ERROR: Cluster configuration was invalid."
+          - Following errors have to be remediated before retrying.
+          - "{{ __ha_cluster_crm_verify.stdout_lines | d('') }}"
+          - "{{ __ha_cluster_crm_verify.stderr_lines | d('') }}"
+      when:
+        - __ha_cluster_crm_verify.rc != 0
+      check_mode: false
+
+
 # Push the new CIB into the cluster
 - name: Copy shadow cib to temp
   ansible.builtin.copy:
@@ -290,12 +331,19 @@
 
 # Meta-attrs is-managed will conflict with maintenance mode as well as
 # individual resource maintenance attributes. Expect will skip their deletion.
+# - name: Disable maintenance mode
+#   ansible.builtin.expect:
+#     command: crm --force configure property maintenance-mode=false
+#     responses:
+#       ".*is-managed.*": "n"
+#       ".*already.*": "n"
+#   check_mode: false
+#   changed_when: true
+#   run_once: true  # noqa: run_once[task]
+
 - name: Disable maintenance mode
-  ansible.builtin.expect:
-    command: crm configure property maintenance-mode=false
-    responses:
-      ".*is-managed.*": "n"
-      ".*already.*": "n"
+  ansible.builtin.command:
+    cmd: crm --force configure property maintenance-mode=false
   check_mode: false
   changed_when: true
   run_once: true  # noqa: run_once[task]

--- a/tasks/shell_crmsh/crm-cluster-properties.yml
+++ b/tasks/shell_crmsh/crm-cluster-properties.yml
@@ -1,11 +1,22 @@
 # SPDX-License-Identifier: MIT
 ---
+# stonith-enabled=true is required for clusters, but this task
+# allows for creation of cluster without stonith enabled.
+# It also ensures that stonith-enabled is always present.
+- name: Append stonith-enabled to ha_cluster_cluster_properties
+  ansible.builtin.set_fact:
+    __ha_cluster_property_attr: "{{
+      (properties_set.attrs + [{'name': 'stonith-enabled', 'value': 'true'}])
+      if properties_set.attrs | selectattr('name','equalto','stonith-enabled')
+       | list | length == 0
+      else properties_set.attrs }}"
+
 - name: Configure cluster properties set
   ansible.builtin.command:
     cmd: >-
-      crm -c {{ __ha_cluster_crm_shadow }}
+      crm --force -c {{ __ha_cluster_crm_shadow }}
       configure property {{ item.name | quote }}={{ item.value | quote }}
-  loop: "{{ properties_set.attrs }}"
+  loop: "{{ __ha_cluster_property_attr }}"
   # Pause ensures that cluster is consistent for further property changes.
   # Setting up crm properties without pause resulted in unstable cluster.
   loop_control:
@@ -13,3 +24,25 @@
   retries: 10
   check_mode: false
   changed_when: not ansible_check_mode
+
+# Get status of cluster properties for validation of stonith-enabled
+- name: Get status of cluster properties
+  ansible.builtin.command:
+    cmd: >-
+      crm --force -c {{ __ha_cluster_crm_shadow }}
+      configure show type:property
+  register: __ha_cluster_crm_show_property
+  check_mode: false
+  changed_when: false
+
+# Warning that stonith-enabled is false and it is not recommended.
+- name: Show warning if stonith-enabled=false
+  ansible.builtin.debug:
+    msg:
+      - "Warning: Property stonith-enabled is set to false."
+      - Property stonith-enabled should be always true for Live clusters!
+      - Set stonith-enabled as true in variable ha_cluster_cluster_properties.
+  when:
+    - __ha_cluster_crm_show_property is defined
+    - "'stonith-enabled=false'
+      in __ha_cluster_crm_show_property.stdout | lower"

--- a/tasks/shell_crmsh/crm-cluster-properties.yml
+++ b/tasks/shell_crmsh/crm-cluster-properties.yml
@@ -7,9 +7,8 @@
   ansible.builtin.set_fact:
     __ha_cluster_property_attr: "{{
       (properties_set.attrs + [{'name': 'stonith-enabled', 'value': 'true'}])
-      if properties_set.attrs | selectattr('name','equalto','stonith-enabled')
-       | list | length == 0
-      else properties_set.attrs }}"
+      if properties_set.attrs | selectattr('name', 'equalto', 'stonith-enabled') | list | length == 0
+      else properties_set.attrs }}"  # yamllint disable-line rule:line-length
 
 - name: Configure cluster properties set
   ansible.builtin.command:

--- a/tasks/shell_crmsh/crm-cluster-properties.yml
+++ b/tasks/shell_crmsh/crm-cluster-properties.yml
@@ -7,8 +7,9 @@
   ansible.builtin.set_fact:
     __ha_cluster_property_attr: "{{
       (properties_set.attrs + [{'name': 'stonith-enabled', 'value': 'true'}])
-      if properties_set.attrs | selectattr('name', 'equalto', 'stonith-enabled') | list | length == 0
-      else properties_set.attrs }}"  # yamllint disable-line rule:line-length
+      if properties_set.attrs
+      | selectattr('name', 'equalto', 'stonith-enabled') | list | length == 0
+      else properties_set.attrs }}"
 
 - name: Configure cluster properties set
   ansible.builtin.command:


### PR DESCRIPTION
## Enhancement:
### main
- package installation changed from `present` to `latest` to accommodate for installation of package updates.
- Images do not come with latest maintenance patches so it is better to update to latest before building cluster.
- @richm @tomjelinek yum should support state `latest` from what I checked.
- New variable added to allow updating of packages `ha_cluster_use_latest_packages`, as discussed below. 

### crmsh
- Changed maintenance tasks to force mode (expect modules were commented out)
- Add task to disable `stonith-enabled` property before proceeding with other `crm configure` steps
- Move cluster property task to end of CIB build so stonith can be enabled at end
- Enhance cluster property task to
  - Append `stonith-enabled=true` if it is missing.
  - Show warning if it was purposefully executed with `stonith-enabled=false`, which is not recommended.
- Execute `crm_verify` to validate shadow CIB before patching. Fail module is used to check return code.

## Reason:
`crmsh 4.6.0` in SUSE Linux Enterprise Server for SAP Applications 15 SP6 no longer ignores error caused by `ha_cluster` workflow.
- crmsh should be executed by `crm init` which sets property `stonit-enabled=false`, allowing for all configuration steps including maintenance mode.
- `ha_cluster` workflow does not use `crm init` so this step was missing, resulting in RC 78 error on SP6 which is thrown for every `crm configure` command except `crm configure property stonith-enabled=false`
```console
ae1ascs:~ # crm configure property maintenance-mode=true
ERROR: error: Resource start-up disabled since no STONITH resources have been defined
ERROR: error: Either configure some or disable STONITH with the stonith-enabled option
ERROR: error: NOTE: Clusters with shared data need STONITH to ensure data integrity
ERROR: crm_verify: Errors found during check: config not valid
```

## Result:
Successfully tested building of SAP HANA and SAP Netweaver clusters on AWS and Google Cloud for OS:
- SUSE Linux Enterprise Server for SAP Applications 15 SP5
- SUSE Linux Enterprise Server for SAP Applications 15 SP6
