### PR TITLE
ci: Use Fedora 41, drop Fedora 39

### DIFF
--- a/.github/workflows/python-unit-test.yml
+++ b/.github/workflows/python-unit-test.yml
@@ -74,7 +74,8 @@ jobs:
           if [ "x${{ matrix.pcs_version }}" == "xmain" ]; then
             echo "0.0.1+ci" > .tarball-version
           fi
-          ./autogen.sh && ./configure --prefix "$pcs_dir" && make && make install
+          # pip adds "/local" so ensure make looks in the right directory when installing
+          ./autogen.sh && ./configure --prefix "$pcs_dir" && make && make prefix="$pcs_dir/local" install
           cd ..
           rm -rf pcs-upstream
           site_pkgs_dir=`python -m site --user-site`
@@ -96,4 +97,4 @@ jobs:
           TOXENV="$toxenvs" lsr_ci_runtox
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5

--- a/.github/workflows/python-unit-test.yml
+++ b/.github/workflows/python-unit-test.yml
@@ -96,4 +96,4 @@ jobs:
           TOXENV="$toxenvs" lsr_ci_runtox
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v4

--- a/.github/workflows/tft.yml
+++ b/.github/workflows/tft.yml
@@ -98,9 +98,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - platform: Fedora-39
-            ansible_version: 2.17
           - platform: Fedora-40
+            ansible_version: 2.17
+          - platform: Fedora-41
             ansible_version: 2.17
           - platform: CentOS-7-latest
             ansible_version: 2.9


### PR DESCRIPTION
Fedora 41 is released, and Fedora 39 will soon be unsupported
