### PR TITLE
fix: list cloud agent packages by architecture

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -74,7 +74,9 @@
           ha_cluster_sbd_enabled | ternary(__ha_cluster_sbd_packages, [])
           +
           ha_cluster_install_cloud_agents |
-            ternary(__ha_cluster_cloud_agents_packages, [])
+            ternary(__ha_cluster_cloud_agents_packages[ansible_architecture]
+                | d(__ha_cluster_cloud_agents_packages['noarch'] | d([])),
+              [])
           +
           ha_cluster_fence_agent_packages }}"
         state: "{{ 'latest' if ha_cluster_use_latest_packages else 'present' }}"

--- a/tests/tests_cluster_basic_cloud_packages.yml
+++ b/tests/tests_cluster_basic_cloud_packages.yml
@@ -7,24 +7,16 @@
   vars:
     ha_cluster_cluster_name: test-cluster
     ha_cluster_install_cloud_agents: true
+    # Only agents available on all architectures are listed so that we don't
+    # need a special case for each architecture.
     __test_agents_rhel_8:
-      - resource-agents-aliyun
-      - resource-agents-gcp
-      - fence-agents-aliyun
       - fence-agents-aws
       - fence-agents-azure-arm
       - fence-agents-gce
+    # RHEL 10 has the same agents as RHEL 9
     __test_agents_rhel_9:
-      - resource-agents-cloud
-      - fence-agents-aliyun
-      - fence-agents-aws
-      - fence-agents-azure-arm
-      - fence-agents-compute
-      - fence-agents-gce
       - fence-agents-ibm-powervs
       - fence-agents-ibm-vpc
-      - fence-agents-kubevirt
-      - fence-agents-openstack
     __test_agents: "{{ (ansible_facts['distribution_major_version'] == '8') |
       ternary(__test_agents_rhel_8, __test_agents_rhel_9) }}"
     __test_eligible: "{{

--- a/vars/CentOS_10.yml
+++ b/vars/CentOS_10.yml
@@ -12,13 +12,29 @@ __ha_cluster_repos:
     name: ResilientStorage
 
 __ha_cluster_cloud_agents_packages:
-  - resource-agents-cloud
-  - fence-agents-aliyun
-  - fence-agents-aws
-  - fence-agents-azure-arm
-  - fence-agents-compute
-  - fence-agents-gce
-  - fence-agents-ibm-powervs
-  - fence-agents-ibm-vpc
-  - fence-agents-kubevirt
-  - fence-agents-openstack
+  x86_64:
+    - resource-agents-cloud
+    - fence-agents-aliyun
+    - fence-agents-aws
+    - fence-agents-azure-arm
+    - fence-agents-gce
+    - fence-agents-ibm-powervs
+    - fence-agents-ibm-vpc
+    - fence-agents-kubevirt
+    - fence-agents-openstack
+  aarch64:
+    - fence-agents-ibm-powervs
+    - fence-agents-ibm-vpc
+    - fence-agents-kubevirt
+  ppc64le:
+    - fence-agents-ibm-powervs
+    - fence-agents-ibm-vpc
+    - fence-agents-kubevirt
+    - fence-agents-openstack
+  s390x:
+    - fence-agents-ibm-powervs
+    - fence-agents-ibm-vpc
+    - fence-agents-kubevirt
+  noarch:
+    - fence-agents-ibm-powervs
+    - fence-agents-ibm-vpc

--- a/vars/CentOS_8.yml
+++ b/vars/CentOS_8.yml
@@ -12,9 +12,14 @@ __ha_cluster_repos:
     name: ResilientStorage
 
 __ha_cluster_cloud_agents_packages:
-  - resource-agents-aliyun
-  - resource-agents-gcp
-  - fence-agents-aliyun
-  - fence-agents-aws
-  - fence-agents-azure-arm
-  - fence-agents-gce
+  x86_64:
+    - resource-agents-aliyun
+    - resource-agents-gcp
+    - fence-agents-aliyun
+    - fence-agents-aws
+    - fence-agents-azure-arm
+    - fence-agents-gce
+  noarch:
+    - fence-agents-aws
+    - fence-agents-azure-arm
+    - fence-agents-gce

--- a/vars/CentOS_9.yml
+++ b/vars/CentOS_9.yml
@@ -12,13 +12,31 @@ __ha_cluster_repos:
     name: ResilientStorage
 
 __ha_cluster_cloud_agents_packages:
-  - resource-agents-cloud
-  - fence-agents-aliyun
-  - fence-agents-aws
-  - fence-agents-azure-arm
-  - fence-agents-compute
-  - fence-agents-gce
-  - fence-agents-ibm-powervs
-  - fence-agents-ibm-vpc
-  - fence-agents-kubevirt
-  - fence-agents-openstack
+  x86_64:
+    - resource-agents-cloud
+    - fence-agents-aliyun
+    - fence-agents-aws
+    - fence-agents-azure-arm
+    - fence-agents-compute
+    - fence-agents-gce
+    - fence-agents-ibm-powervs
+    - fence-agents-ibm-vpc
+    - fence-agents-kubevirt
+    - fence-agents-openstack
+  aarch64:
+    - fence-agents-ibm-powervs
+    - fence-agents-ibm-vpc
+    - fence-agents-kubevirt
+  ppc64le:
+    - fence-agents-compute
+    - fence-agents-ibm-powervs
+    - fence-agents-ibm-vpc
+    - fence-agents-kubevirt
+    - fence-agents-openstack
+  s390x:
+    - fence-agents-ibm-powervs
+    - fence-agents-ibm-vpc
+    - fence-agents-kubevirt
+  noarch:
+    - fence-agents-ibm-powervs
+    - fence-agents-ibm-vpc

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: MIT
 ---
 # Put internal variables here with Fedora specific values.
-__ha_cluster_cloud_agents_packages: []
+__ha_cluster_cloud_agents_packages: {}

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -23,7 +23,7 @@ __ha_cluster_fullstack_node_packages:
   - resource-agents
   - pacemaker
 
-__ha_cluster_cloud_agents_packages: []
+__ha_cluster_cloud_agents_packages: {}
 
 __ha_cluster_qdevice_node_packages:
   - corosync-qdevice

--- a/vars/RedHat_10.yml
+++ b/vars/RedHat_10.yml
@@ -12,13 +12,29 @@ __ha_cluster_repos:
     name: Resilient Storage
 
 __ha_cluster_cloud_agents_packages:
-  - resource-agents-cloud
-  - fence-agents-aliyun
-  - fence-agents-aws
-  - fence-agents-azure-arm
-  - fence-agents-compute
-  - fence-agents-gce
-  - fence-agents-ibm-powervs
-  - fence-agents-ibm-vpc
-  - fence-agents-kubevirt
-  - fence-agents-openstack
+  x86_64:
+    - resource-agents-cloud
+    - fence-agents-aliyun
+    - fence-agents-aws
+    - fence-agents-azure-arm
+    - fence-agents-gce
+    - fence-agents-ibm-powervs
+    - fence-agents-ibm-vpc
+    - fence-agents-kubevirt
+    - fence-agents-openstack
+  aarch64:
+    - fence-agents-ibm-powervs
+    - fence-agents-ibm-vpc
+    - fence-agents-kubevirt
+  ppc64le:
+    - fence-agents-ibm-powervs
+    - fence-agents-ibm-vpc
+    - fence-agents-kubevirt
+    - fence-agents-openstack
+  s390x:
+    - fence-agents-ibm-powervs
+    - fence-agents-ibm-vpc
+    - fence-agents-kubevirt
+  noarch:
+    - fence-agents-ibm-powervs
+    - fence-agents-ibm-vpc

--- a/vars/RedHat_8.yml
+++ b/vars/RedHat_8.yml
@@ -12,9 +12,14 @@ __ha_cluster_repos:
     name: Resilient Storage
 
 __ha_cluster_cloud_agents_packages:
-  - resource-agents-aliyun
-  - resource-agents-gcp
-  - fence-agents-aliyun
-  - fence-agents-aws
-  - fence-agents-azure-arm
-  - fence-agents-gce
+  x86_64:
+    - resource-agents-aliyun
+    - resource-agents-gcp
+    - fence-agents-aliyun
+    - fence-agents-aws
+    - fence-agents-azure-arm
+    - fence-agents-gce
+  noarch:
+    - fence-agents-aws
+    - fence-agents-azure-arm
+    - fence-agents-gce

--- a/vars/RedHat_9.yml
+++ b/vars/RedHat_9.yml
@@ -12,13 +12,31 @@ __ha_cluster_repos:
     name: Resilient Storage
 
 __ha_cluster_cloud_agents_packages:
-  - resource-agents-cloud
-  - fence-agents-aliyun
-  - fence-agents-aws
-  - fence-agents-azure-arm
-  - fence-agents-compute
-  - fence-agents-gce
-  - fence-agents-ibm-powervs
-  - fence-agents-ibm-vpc
-  - fence-agents-kubevirt
-  - fence-agents-openstack
+  x86_64:
+    - resource-agents-cloud
+    - fence-agents-aliyun
+    - fence-agents-aws
+    - fence-agents-azure-arm
+    - fence-agents-compute
+    - fence-agents-gce
+    - fence-agents-ibm-powervs
+    - fence-agents-ibm-vpc
+    - fence-agents-kubevirt
+    - fence-agents-openstack
+  aarch64:
+    - fence-agents-ibm-powervs
+    - fence-agents-ibm-vpc
+    - fence-agents-kubevirt
+  ppc64le:
+    - fence-agents-compute
+    - fence-agents-ibm-powervs
+    - fence-agents-ibm-vpc
+    - fence-agents-kubevirt
+    - fence-agents-openstack
+  s390x:
+    - fence-agents-ibm-powervs
+    - fence-agents-ibm-vpc
+    - fence-agents-kubevirt
+  noarch:
+    - fence-agents-ibm-powervs
+    - fence-agents-ibm-vpc

--- a/vars/Suse.yml
+++ b/vars/Suse.yml
@@ -23,7 +23,7 @@ __ha_cluster_role_essential_packages:
 
 __ha_cluster_fullstack_node_packages: []
 
-__ha_cluster_cloud_agents_packages: []
+__ha_cluster_cloud_agents_packages: {}
 
 __ha_cluster_qdevice_node_packages:
   - corosync-qdevice


### PR DESCRIPTION
Enhancement:
list cloud agent packages per architecture

Reason:
not all cloud agents are available for all architectures

Result:
role doesn't fail anymore due to it trying to install packages not available for a given architecture

Issue Tracker Tickets (Jira or BZ if any):
https://issues.redhat.com/browse/RHEL-55538
