### PR TITLE
fix: update constraints commands syntax for pcs-0.12

### DIFF
--- a/tasks/shell_pcs/pcs-cib-constraint-colocation.yml
+++ b/tasks/shell_pcs/pcs-cib-constraint-colocation.yml
@@ -25,9 +25,23 @@
       {% endif %}
       {{ constraint.resource_leader.id | quote }}
       {% for option in constraint.options | d([]) if option.name == 'score' %}
-        {{ option.value | quote }}
+        {% if
+          'pcmk.constraint.colocation.simple.options.score'
+          in __ha_cluster_pcs_capabilities
+        %}
+          {{ ('score=' ~ option.value) | quote }}
+        {% else %}
+          {{ option.value | quote }}
+        {% endif %}
       {% else %}
-        INFINITY
+        {% if
+          'pcmk.constraint.colocation.simple.options.score'
+          in __ha_cluster_pcs_capabilities
+        %}
+          score=INFINITY
+        {% else %}
+          INFINITY
+        {% endif %}
       {% endfor %}
       {% if constraint.id | d() %}
         id={{ constraint.id | quote }}

--- a/tasks/shell_pcs/pcs-cib-constraint-location.yml
+++ b/tasks/shell_pcs/pcs-cib-constraint-location.yml
@@ -25,7 +25,14 @@
         {% for option in constraint.options | d([]) %}
           {{ option.name | quote }}={{ option.value | quote }}
         {% endfor %}
-        {{ constraint.rule }}
+        {% if
+          'pcmk.constraint.location.simple.rule.rule-as-one-argument'
+          in __ha_cluster_pcs_capabilities
+        %}
+          {{ constraint.rule | quote }}
+        {% else %}
+          {{ constraint.rule }}
+        {% endif %}
       {% elif
         (constraint.id | d())
         or (
@@ -42,9 +49,23 @@
         {% endif %}
         {{ constraint.node | quote }}
         {% for option in constraint.options | d([]) if option.name == 'score' %}
-          {{ option.value | quote }}
+          {% if
+            'pcmk.constraint.location.simple.options.score'
+            in __ha_cluster_pcs_capabilities
+          %}
+            {{ ('score=' ~ option.value) | quote }}
+          {% else %}
+            {{ option.value | quote }}
+          {% endif %}
         {% else %}
-          INFINITY
+          {% if
+            'pcmk.constraint.location.simple.options.score'
+            in __ha_cluster_pcs_capabilities
+          %}
+            score=INFINITY
+          {% else %}
+            INFINITY
+          {% endif %}
         {% endfor %}
         {% for option in constraint.options | d([]) if option.name != 'score' %}
           {{ option.name | quote }}={{ option.value | quote }}


### PR DESCRIPTION
Enhancement:
Update the role to pcs-0.12 command syntax

Reason:
New version of pcs brings updated syntax of some commands. Previous syntax is deprecated but it still works. It will be dropped eventually, though, and the role should be ready for that.

Result:
Role uses new pcs syntax if new enough pcs is available.

Issue Tracker Tickets (Jira or BZ if any):
https://issues.redhat.com/browse/RHEL-45303
