### PR TITLE
fix: restart qdevice when its certificates have been regenerated

### DIFF
--- a/tasks/shell_pcs/cluster-setup-keys.yml
+++ b/tasks/shell_pcs/cluster-setup-keys.yml
@@ -61,10 +61,10 @@
       {{ ha_cluster_cluster_name | quote }}
       {{ __ha_cluster_qdevice_host | quote }}
   check_mode: false
-  register: __ha_cluster_qdevice_certs
+  register: __ha_cluster_qdevice_certs_cli
   changed_when:
-    - __ha_cluster_qdevice_certs.rc == 0
-    - __ha_cluster_qdevice_certs.stdout_lines[-1]
+    - __ha_cluster_qdevice_certs_cli.rc == 0
+    - __ha_cluster_qdevice_certs_cli.stdout_lines[-1]
       != "** certificate already present **"
   when:
     - __ha_cluster_qdevice_in_use
@@ -76,6 +76,7 @@
   pcs_qdevice_certs:
     qnetd_host: "{{ __ha_cluster_qdevice_host }}"
     cluster_name: "{{ ha_cluster_cluster_name }}"
+  register: __ha_cluster_qdevice_certs_api
   when:
     - __ha_cluster_qdevice_in_use
     - __ha_cluster_qdevice_model == "net"

--- a/tasks/shell_pcs/cluster-start-and-reload.yml
+++ b/tasks/shell_pcs/cluster-start-and-reload.yml
@@ -36,7 +36,8 @@
         or __ha_cluster_distribute_pacemaker_authkey.changed
         or (__ha_cluster_sbd_service_enable_disable.changed | d(false))
         or (__ha_cluster_distribute_sbd_config.changed | d(false))
-        or (__ha_cluster_qdevice_certs.changed | d(false))
+        or (__ha_cluster_qdevice_certs_cli.changed | d(false))
+        or (__ha_cluster_qdevice_certs_api.changed | d(false))
     - >
         item != 'corosync-qdevice'
         or 'corosync-qdevice.service' in ansible_facts.services

--- a/tests/tasks/assert_qdevice_in_cluster.yml
+++ b/tests/tasks/assert_qdevice_in_cluster.yml
@@ -16,6 +16,9 @@
     cmd: pcs -- quorum device status
   register: __test_quorum_device_status
   changed_when: false
+  retries: 6
+  delay: 10
+  until: "'State:\t\t\tConnected' in __test_quorum_device_status.stdout"  # noqa no-tabs
 
 # yamllint disable rule:line-length
 - name: Assert qdevice connected

--- a/tests/tests_cluster_basic_custom_packages.yml
+++ b/tests/tests_cluster_basic_custom_packages.yml
@@ -38,4 +38,4 @@
         - name: Check installed packages
           assert:
             that:
-              - "'{{ __test_extra_package }}' in ansible_facts.packages"
+              - __test_extra_package in ansible_facts.packages


### PR DESCRIPTION
Enhancement:
Always restart qdevice daemon on cluster nodes when certificates for qdevice - qnetd communication have changed.

Reason:
With the restart missing, qdevice and qnetd were not able to communicate in certain scenarios. This basically rendered qdevice not working until the cluster is restarted. 

Result:
Communication between qdevice (cluster nodes) and qnetd (quorum device) works.

Issue Tracker Tickets (Jira or BZ if any):
none