### PR TITLE
feat: export pcsd and OS configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1577,6 +1577,10 @@ may not be present in the export.
   * [`ha_cluster_enable_repos`](#ha_cluster_enable_repos) - RHEL and CentOS only
   * [`ha_cluster_enable_repos_resilient_storage`](#ha_cluster_enable_repos_resilient_storage) -
     RHEL and CentOS only
+  * [`ha_cluster_manage_firewall`](#ha_cluster_manage_firewall) (requires
+    `python3-firewall` to be installed on managed nodes)
+  * [`ha_cluster_manage_selinux`](#ha_cluster_manage_selinux) (requires
+    `python3-policycoreutils` to be installed on managed nodes)
   * [`ha_cluster_cluster_present`](#ha_cluster_cluster_present)
   * [`ha_cluster_start_on_boot`](#ha_cluster_start_on_boot)
   * [`ha_cluster_install_cloud_agents`](#ha_cluster_install_cloud_agents) -
@@ -1613,6 +1617,10 @@ may not be present in the export.
     These are supposed to contain paths to files with TLS certificate and
     private key for pcsd. Since the certificate and key themselves are not
     exported, these variables are not present in the export either.
+  * [`ha_cluster_pcsd_certificates`](#ha_cluster_pcsd_certificates) - The value
+    of this variable is set to the variable `certificate_requests` in the
+    `certificate` role. See the `certificate` role documentation to check if it
+    provides any means for exporting configuration.
   * [`ha_cluster_regenerate_keys`](#ha_cluster_regenerate_keys) - It is your
     responsibility to decide if you want to use existing keys or generate new
     ones.

--- a/README.md
+++ b/README.md
@@ -1574,8 +1574,14 @@ Note that depending on pcs version installed on managed nodes, certain variables
 may not be present in the export.
 
 * Following variables are present in the export:
+  * [`ha_cluster_enable_repos`](#ha_cluster_enable_repos) - RHEL and CentOS only
+  * [`ha_cluster_enable_repos_resilient_storage`](#ha_cluster_enable_repos_resilient_storage) -
+    RHEL and CentOS only
   * [`ha_cluster_cluster_present`](#ha_cluster_cluster_present)
   * [`ha_cluster_start_on_boot`](#ha_cluster_start_on_boot)
+  * [`ha_cluster_install_cloud_agents`](#ha_cluster_install_cloud_agents) -
+    RHEL and CentOS only
+  * [`ha_cluster_pcs_permission_list`](#ha_cluster_pcs_permission_list)
   * [`ha_cluster_cluster_name`](#ha_cluster_cluster_name)
   * [`ha_cluster_transport`](#ha_cluster_transport)
   * [`ha_cluster_totem`](#ha_cluster_totem)
@@ -1588,6 +1594,14 @@ may not be present in the export.
   * [`ha_cluster_hacluster_password`](#ha_cluster_hacluster_password) - This is
     a mandatory variable for the role but it cannot be extracted from existing
     clusters.
+  * [`ha_cluster_hacluster_qdevice_password`](#ha_cluster_hacluster_qdevice_password) -
+    Cannot be extracted from existing clusters.
+  * [`ha_cluster_fence_agent_packages`](#ha_cluster_fence_agent_packages)
+  * [`ha_cluster_extra_packages`](#ha_cluster_extra_packages) - Cannot be
+    extracted from existing clusters.
+  * [`ha_cluster_use_latest_packages`](#ha_cluster_use_latest_packages) - It is
+    your responsibility to decide if you want to upgrade cluster packages to
+    their latest version.
   * [`ha_cluster_corosync_key_src`](#ha_cluster_corosync_key_src),
     [`ha_cluster_pacemaker_key_src`](#ha_cluster_pacemaker_key_src) and
     [`ha_cluster_fence_virt_key_src`](#ha_cluster_fence_virt_key_src) - These
@@ -1595,6 +1609,10 @@ may not be present in the export.
     themselves are not exported, these variables are not present in the export
     either. Corosync and pacemaker keys are supposed to be unique for each
     cluster.
+  * [`ha_cluster_pcsd_public_key_src` and `ha_cluster_pcsd_private_key_src`](#ha_cluster_pcsd_public_key_src-ha_cluster_pcsd_private_key_src) -
+    These are supposed to contain paths to files with TLS certificate and
+    private key for pcsd. Since the certificate and key themselves are not
+    exported, these variables are not present in the export either.
   * [`ha_cluster_regenerate_keys`](#ha_cluster_regenerate_keys) - It is your
     responsibility to decide if you want to use existing keys or generate new
     ones.

--- a/library/ha_cluster_info.py
+++ b/library/ha_cluster_info.py
@@ -138,9 +138,13 @@ def export_pcsd_configuration() -> Dict[str, Any]:
     """
     result: dict[str, Any] = dict()
 
-    pcs_permissions = loader.get_pcsd_local_cluster_permissions()
-    if pcs_permissions is not None:
-        result["ha_cluster_pcs_permission_list"] = pcs_permissions
+    pcsd_settings_dict = loader.get_pcsd_settings_conf()
+    if pcsd_settings_dict is not None:
+        pcs_permissions = exporter.export_pcs_permission_list(
+            pcsd_settings_dict
+        )
+        if pcs_permissions is not None:
+            result["ha_cluster_pcs_permission_list"] = pcs_permissions
 
     return result
 

--- a/module_utils/ha_cluster_lsr/info/exporter.py
+++ b/module_utils/ha_cluster_lsr/info/exporter.py
@@ -48,6 +48,55 @@ def _handle_missing_key(data: Dict[str, Any], data_desc: str) -> Iterator[None]:
         raise JsonMissingKey(e.args[0], data, data_desc) from e
 
 
+def export_enable_repos_ha(dnf_repolist: str) -> bool:
+    """
+    Check whether high availability repository is enabled based on dnf repolist
+
+    dnf_repolist -- text output of 'dnf repolist'
+    """
+    repo_strings = ["highavailability", "HighAvailability"]
+    return any(repo in dnf_repolist for repo in repo_strings)
+
+
+def export_enable_repos_rs(dnf_repolist: str) -> bool:
+    """
+    Check whether resilient storage repository is enabled based on dnf repolist
+
+    dnf_repolist -- text output of 'dnf repolist'
+    """
+    repo_strings = ["resilientstorage"]
+    return any(repo in dnf_repolist for repo in repo_strings)
+
+
+def export_install_cloud_agents(installed_packages: List[str]) -> bool:
+    """
+    Check whether cloud agent packages are installed
+
+    installed packages -- list of names of installed packages
+    """
+    # List of cloud agent packages is taken from vars/RedHat_*.yml and
+    # vars/CentOS_*.yml
+    # They are hardcoded here to avoid dependency on pyyaml which may or may
+    # not be available.
+    # We don't need to check for architecture - a package not available for an
+    # architecture will never be listed as installed on that architecture.
+    cloud_agent_packages = {
+        "fence-agents-aliyun",
+        "fence-agents-aws",
+        "fence-agents-azure-arm",
+        "fence-agents-compute",
+        "fence-agents-gce",
+        "fence-agents-ibm-powervs",
+        "fence-agents-ibm-vpc",
+        "fence-agents-kubevirt",
+        "fence-agents-openstack",
+        "resource-agents-aliyun",
+        "resource-agents-cloud",
+        "resource-agents-gcp",
+    }
+    return bool(cloud_agent_packages.intersection(installed_packages))
+
+
 def export_start_on_boot(
     corosync_enabled: bool, pacemaker_enabled: bool
 ) -> bool:

--- a/module_utils/ha_cluster_lsr/info/loader.py
+++ b/module_utils/ha_cluster_lsr/info/loader.py
@@ -218,42 +218,19 @@ def get_pcsd_known_hosts() -> Dict[str, str]:
         raise JsonParseError(str(e), "not logging data", "known hosts") from e
 
 
-def get_pcsd_local_cluster_permissions() -> Optional[List[Dict[str, Any]]]:
+def get_pcsd_settings_conf() -> Optional[Dict[str, Any]]:
     """
-    Load pcsd local cluster permissions
+    Load pcsd config file pcs_settings.conf
     """
     # There is no pcs interface for the file yet, so we parse the file directly.
     if not os.path.exists(PCSD_SETTINGS_PATH):
         return None
 
-    result: List[Dict[str, Any]] = []
     try:
         with open(
             PCSD_SETTINGS_PATH, "r", encoding="utf-8"
         ) as pcsd_settings_file:
-            pcsd_settings = json.load(pcsd_settings_file)
-        permission_dict = pcsd_settings.get("permissions")
-        if not isinstance(permission_dict, dict):
-            return result
-        permission_list = permission_dict.get("local_cluster")
-        if not isinstance(permission_list, list):
-            return result
-        for permission_item in permission_list:
-            if (
-                "type" not in permission_item
-                or "name" not in permission_item
-                or "allow" not in permission_item
-                or not isinstance(permission_item["allow"], list)
-            ):
-                continue
-            result.append(
-                {
-                    "type": permission_item["type"],
-                    "name": permission_item["name"],
-                    "allow_list": list(permission_item["allow"]),
-                }
-            )
-        return result
+            file_data = pcsd_settings_file.read()
+            return json.loads(file_data)
     except json.JSONDecodeError as e:
-        # cannot show actual data as they contain sensitive information
-        raise JsonParseError(str(e), "not logging data", "pcsd settings") from e
+        raise JsonParseError(str(e), file_data, "pcsd settings") from e

--- a/module_utils/ha_cluster_lsr/info/loader.py
+++ b/module_utils/ha_cluster_lsr/info/loader.py
@@ -108,28 +108,26 @@ def is_rhel_or_clone() -> bool:
     return False
 
 
-def is_rhel_repo_enabled(
-    run_command: CommandRunner, repo_strings: Tuple[str, ...]
-) -> bool:
+def get_dnf_repolist(run_command: CommandRunner) -> Optional[str]:
     """
-    Check whether a dnf repo specified by its ID or name is enabled
-
-    repo_id -- substring of repo ID or name
+    Get list of enabled repositories or None on error
     """
     # wokeignore:rule=dummy
     rc, stdout, dummy_stderr = run_command(["dnf", "repolist"], {})
-    return rc == 0 and any(repo in stdout for repo in repo_strings)
+    return stdout if rc == 0 else None
 
 
-def list_rhel_installed_packages(run_command: CommandRunner) -> List[str]:
+def get_rpm_installed_packages(
+    run_command: CommandRunner,
+) -> Optional[List[str]]:
     """
-    Return names of packages installed on a RHEL system
+    Return names of installed packages or None on error
     """
     # wokeignore:rule=dummy
     rc, stdout, dummy_stderr = run_command(
         ["rpm", "--query", "--all", "--queryformat", "%{NAME}\\n"], {}
     )
-    return stdout.splitlines() if rc == 0 else []
+    return stdout.splitlines() if rc == 0 else None
 
 
 def is_service_enabled(run_command: CommandRunner, service: str) -> bool:

--- a/tests/tests_cluster_advanced_knet_full.yml
+++ b/tests/tests_cluster_advanced_knet_full.yml
@@ -130,6 +130,9 @@
             __test_exported_config: >
               {{
                 ha_cluster_facts | combine({
+                  'ha_cluster_enable_repos': 'it depends on test environment',
+                  'ha_cluster_enable_repos_resilient_storage': 'it depends on test environment',
+                  'ha_cluster_install_cloud_agents': 'it depends on test environment',
                   'ha_cluster_node_options': 'it depends on test environment'
                 })
               }}
@@ -157,6 +160,13 @@
                 crypto: "{{ ha_cluster_transport.crypto }}"
               ha_cluster_totem: "{{ ha_cluster_totem }}"
               ha_cluster_quorum: "{{ ha_cluster_quorum }}"
+              ha_cluster_pcs_permission_list:
+                - name: haclient
+                  type: group
+                  allow_list: ["grant", "read", "write"]
+              ha_cluster_enable_repos: "it depends on test environment"
+              ha_cluster_enable_repos_resilient_storage: "it depends on test environment"
+              ha_cluster_install_cloud_agents: "it depends on test environment"
               ha_cluster_node_options: "it depends on test environment"
           block:
             - name: Print exported configuration

--- a/tests/tests_cluster_advanced_knet_full.yml
+++ b/tests/tests_cluster_advanced_knet_full.yml
@@ -132,6 +132,8 @@
                 ha_cluster_facts | combine({
                   'ha_cluster_enable_repos': 'it depends on test environment',
                   'ha_cluster_enable_repos_resilient_storage': 'it depends on test environment',
+                  'ha_cluster_manage_firewall': 'it depends on test environment',
+                  'ha_cluster_manage_selinux': 'it depends on test environment',
                   'ha_cluster_install_cloud_agents': 'it depends on test environment',
                   'ha_cluster_node_options': 'it depends on test environment'
                 })
@@ -166,6 +168,8 @@
                   allow_list: ["grant", "read", "write"]
               ha_cluster_enable_repos: "it depends on test environment"
               ha_cluster_enable_repos_resilient_storage: "it depends on test environment"
+              ha_cluster_manage_firewall: "it depends on test environment"
+              ha_cluster_manage_selinux: "it depends on test environment"
               ha_cluster_install_cloud_agents: "it depends on test environment"
               ha_cluster_node_options: "it depends on test environment"
           block:

--- a/tests/tests_cluster_advanced_knet_implicit.yml
+++ b/tests/tests_cluster_advanced_knet_implicit.yml
@@ -68,6 +68,9 @@
             __test_exported_config: >
               {{
                 ha_cluster_facts | combine({
+                  'ha_cluster_enable_repos': 'it depends on test environment',
+                  'ha_cluster_enable_repos_resilient_storage': 'it depends on test environment',
+                  'ha_cluster_install_cloud_agents': 'it depends on test environment',
                   'ha_cluster_node_options': 'it depends on test environment'
                 })
               }}
@@ -78,6 +81,13 @@
               ha_cluster_transport:
                 type: knet
                 crypto: "{{ ha_cluster_transport.crypto }}"
+              ha_cluster_pcs_permission_list:
+                - name: haclient
+                  type: group
+                  allow_list: ["grant", "read", "write"]
+              ha_cluster_enable_repos: "it depends on test environment"
+              ha_cluster_enable_repos_resilient_storage: "it depends on test environment"
+              ha_cluster_install_cloud_agents: "it depends on test environment"
               ha_cluster_node_options: "it depends on test environment"
           block:
             - name: Print exported configuration

--- a/tests/tests_cluster_advanced_udp_full.yml
+++ b/tests/tests_cluster_advanced_udp_full.yml
@@ -94,6 +94,8 @@
                 ha_cluster_facts | combine({
                   'ha_cluster_enable_repos': 'it depends on test environment',
                   'ha_cluster_enable_repos_resilient_storage': 'it depends on test environment',
+                  'ha_cluster_manage_firewall': 'it depends on test environment',
+                  'ha_cluster_manage_selinux': 'it depends on test environment',
                   'ha_cluster_install_cloud_agents': 'it depends on test environment',
                   'ha_cluster_node_options': 'it depends on test environment'
                 })
@@ -111,6 +113,8 @@
                   allow_list: ["grant", "read", "write"]
               ha_cluster_enable_repos: "it depends on test environment"
               ha_cluster_enable_repos_resilient_storage: "it depends on test environment"
+              ha_cluster_manage_firewall: "it depends on test environment"
+              ha_cluster_manage_selinux: "it depends on test environment"
               ha_cluster_install_cloud_agents: "it depends on test environment"
               ha_cluster_node_options: "it depends on test environment"
           block:

--- a/tests/tests_cluster_advanced_udp_full.yml
+++ b/tests/tests_cluster_advanced_udp_full.yml
@@ -92,6 +92,9 @@
             __test_exported_config: >
               {{
                 ha_cluster_facts | combine({
+                  'ha_cluster_enable_repos': 'it depends on test environment',
+                  'ha_cluster_enable_repos_resilient_storage': 'it depends on test environment',
+                  'ha_cluster_install_cloud_agents': 'it depends on test environment',
                   'ha_cluster_node_options': 'it depends on test environment'
                 })
               }}
@@ -102,6 +105,13 @@
               ha_cluster_transport: "{{ ha_cluster_transport }}"
               ha_cluster_totem: "{{ ha_cluster_totem }}"
               ha_cluster_quorum: "{{ ha_cluster_quorum }}"
+              ha_cluster_pcs_permission_list:
+                - name: haclient
+                  type: group
+                  allow_list: ["grant", "read", "write"]
+              ha_cluster_enable_repos: "it depends on test environment"
+              ha_cluster_enable_repos_resilient_storage: "it depends on test environment"
+              ha_cluster_install_cloud_agents: "it depends on test environment"
               ha_cluster_node_options: "it depends on test environment"
           block:
             - name: Print exported configuration

--- a/tests/tests_cluster_basic.yml
+++ b/tests/tests_cluster_basic.yml
@@ -120,6 +120,8 @@
                 ha_cluster_facts | combine({
                   'ha_cluster_enable_repos': 'it depends on test environment',
                   'ha_cluster_enable_repos_resilient_storage': 'it depends on test environment',
+                  'ha_cluster_manage_firewall': 'it depends on test environment',
+                  'ha_cluster_manage_selinux': 'it depends on test environment',
                   'ha_cluster_install_cloud_agents': 'it depends on test environment',
                   'ha_cluster_node_options': 'it depends on test environment'
                 })
@@ -141,6 +143,8 @@
                   allow_list: ["grant", "read", "write"]
               ha_cluster_enable_repos: "it depends on test environment"
               ha_cluster_enable_repos_resilient_storage: "it depends on test environment"
+              ha_cluster_manage_firewall: "it depends on test environment"
+              ha_cluster_manage_selinux: "it depends on test environment"
               ha_cluster_install_cloud_agents: "it depends on test environment"
               ha_cluster_node_options: "it depends on test environment"
           block:

--- a/tests/tests_cluster_basic.yml
+++ b/tests/tests_cluster_basic.yml
@@ -118,6 +118,9 @@
             __test_exported_config: >
               {{
                 ha_cluster_facts | combine({
+                  'ha_cluster_enable_repos': 'it depends on test environment',
+                  'ha_cluster_enable_repos_resilient_storage': 'it depends on test environment',
+                  'ha_cluster_install_cloud_agents': 'it depends on test environment',
                   'ha_cluster_node_options': 'it depends on test environment'
                 })
               }}
@@ -132,6 +135,13 @@
                     value: aes256
                   - name: hash
                     value: sha256
+              ha_cluster_pcs_permission_list:
+                - name: haclient
+                  type: group
+                  allow_list: ["grant", "read", "write"]
+              ha_cluster_enable_repos: "it depends on test environment"
+              ha_cluster_enable_repos_resilient_storage: "it depends on test environment"
+              ha_cluster_install_cloud_agents: "it depends on test environment"
               ha_cluster_node_options: "it depends on test environment"
           block:
             - name: Print exported configuration

--- a/tests/tests_cluster_basic_cloud_packages.yml
+++ b/tests/tests_cluster_basic_cloud_packages.yml
@@ -66,6 +66,8 @@
                 ha_cluster_facts | combine({
                   'ha_cluster_enable_repos': 'it depends on test environment',
                   'ha_cluster_enable_repos_resilient_storage': 'it depends on test environment',
+                  'ha_cluster_manage_firewall': 'it depends on test environment',
+                  'ha_cluster_manage_selinux': 'it depends on test environment',
                   'ha_cluster_node_options': 'it depends on test environment'
                 })
               }}
@@ -87,6 +89,8 @@
                   allow_list: ["grant", "read", "write"]
               ha_cluster_enable_repos: "it depends on test environment"
               ha_cluster_enable_repos_resilient_storage: "it depends on test environment"
+              ha_cluster_manage_firewall: "it depends on test environment"
+              ha_cluster_manage_selinux: "it depends on test environment"
               ha_cluster_node_options: "it depends on test environment"
           block:
             - name: Print exported configuration

--- a/tests/tests_cluster_basic_cloud_packages.yml
+++ b/tests/tests_cluster_basic_cloud_packages.yml
@@ -7,6 +7,7 @@
   vars:
     ha_cluster_cluster_name: test-cluster
     ha_cluster_install_cloud_agents: true
+    ha_cluster_export_configuration: true
     # Only agents available on all architectures are listed so that we don't
     # need a special case for each architecture.
     __test_agents_rhel_8:
@@ -57,6 +58,49 @@
 
         - name: Check cluster status
           include_tasks: tasks/assert_cluster_running.yml
+
+        - name: Check exported configuration
+          vars:
+            __test_exported_config: >
+              {{
+                ha_cluster_facts | combine({
+                  'ha_cluster_enable_repos': 'it depends on test environment',
+                  'ha_cluster_enable_repos_resilient_storage': 'it depends on test environment',
+                  'ha_cluster_node_options': 'it depends on test environment'
+                })
+              }}
+            __test_expected_config:
+              ha_cluster_install_cloud_agents: true
+              ha_cluster_cluster_present: true
+              ha_cluster_cluster_name: test-cluster
+              ha_cluster_start_on_boot: true
+              ha_cluster_transport:
+                type: knet
+                crypto:
+                  - name: cipher
+                    value: aes256
+                  - name: hash
+                    value: sha256
+              ha_cluster_pcs_permission_list:
+                - name: haclient
+                  type: group
+                  allow_list: ["grant", "read", "write"]
+              ha_cluster_enable_repos: "it depends on test environment"
+              ha_cluster_enable_repos_resilient_storage: "it depends on test environment"
+              ha_cluster_node_options: "it depends on test environment"
+          block:
+            - name: Print exported configuration
+              debug:
+                var: __test_exported_config
+
+            - name: Print expected configuration
+              debug:
+                var: __test_expected_config
+
+            - name: Compare expected and exported configuration
+              assert:
+                that:
+                  - __test_exported_config == __test_expected_config
 
     - name: Message
       debug:

--- a/tests/tests_cluster_basic_disabled.yml
+++ b/tests/tests_cluster_basic_disabled.yml
@@ -45,6 +45,8 @@
                 ha_cluster_facts | combine({
                   'ha_cluster_enable_repos': 'it depends on test environment',
                   'ha_cluster_enable_repos_resilient_storage': 'it depends on test environment',
+                  'ha_cluster_manage_firewall': 'it depends on test environment',
+                  'ha_cluster_manage_selinux': 'it depends on test environment',
                   'ha_cluster_install_cloud_agents': 'it depends on test environment',
                   'ha_cluster_node_options': 'it depends on test environment'
                 })
@@ -66,6 +68,8 @@
                   allow_list: ["grant", "read", "write"]
               ha_cluster_enable_repos: "it depends on test environment"
               ha_cluster_enable_repos_resilient_storage: "it depends on test environment"
+              ha_cluster_manage_firewall: "it depends on test environment"
+              ha_cluster_manage_selinux: "it depends on test environment"
               ha_cluster_install_cloud_agents: "it depends on test environment"
               ha_cluster_node_options: "it depends on test environment"
           block:

--- a/tests/tests_export_doesnt_destroy_cluster.yml
+++ b/tests/tests_export_doesnt_destroy_cluster.yml
@@ -11,6 +11,9 @@
         __test_exported_config: >
           {{
             ha_cluster_facts | combine({
+              'ha_cluster_enable_repos': 'it depends on test environment',
+              'ha_cluster_enable_repos_resilient_storage': 'it depends on test environment',
+              'ha_cluster_install_cloud_agents': 'it depends on test environment',
               'ha_cluster_node_options': 'it depends on test environment'
             })
           }}
@@ -20,6 +23,13 @@
           ha_cluster_start_on_boot: true
           ha_cluster_transport:
             type: udp
+          ha_cluster_pcs_permission_list:
+            - name: haclient
+              type: group
+              allow_list: ["grant", "read", "write"]
+          ha_cluster_enable_repos: "it depends on test environment"
+          ha_cluster_enable_repos_resilient_storage: "it depends on test environment"
+          ha_cluster_install_cloud_agents: "it depends on test environment"
           ha_cluster_node_options: "it depends on test environment"
       block:
         - name: Set up test environment

--- a/tests/tests_export_doesnt_destroy_cluster.yml
+++ b/tests/tests_export_doesnt_destroy_cluster.yml
@@ -13,6 +13,8 @@
             ha_cluster_facts | combine({
               'ha_cluster_enable_repos': 'it depends on test environment',
               'ha_cluster_enable_repos_resilient_storage': 'it depends on test environment',
+              'ha_cluster_manage_firewall': 'it depends on test environment',
+              'ha_cluster_manage_selinux': 'it depends on test environment',
               'ha_cluster_install_cloud_agents': 'it depends on test environment',
               'ha_cluster_node_options': 'it depends on test environment'
             })
@@ -29,6 +31,8 @@
               allow_list: ["grant", "read", "write"]
           ha_cluster_enable_repos: "it depends on test environment"
           ha_cluster_enable_repos_resilient_storage: "it depends on test environment"
+          ha_cluster_manage_firewall: "it depends on test environment"
+          ha_cluster_manage_selinux: "it depends on test environment"
           ha_cluster_install_cloud_agents: "it depends on test environment"
           ha_cluster_node_options: "it depends on test environment"
       block:

--- a/tests/tests_export_firewall_selinux.yml
+++ b/tests/tests_export_firewall_selinux.yml
@@ -1,17 +1,19 @@
 # SPDX-License-Identifier: MIT
 ---
-- name: Cluster with knet transport, transport type not specified
+# The role is limited to *adding* ports in firewall and selinux and cannot be
+# used for *removing* ports. If the underlying system is already configured
+# with HA cluster services and ports in firewall and selinux, the role would
+# not change that even if run with ha_cluster_manage_firewall=False. Hence,
+# only ha_cluster_manage_firewall=true is tested. The same applies to
+# ha_cluster_manage_selinux.
+- name: Exporting manage_firewall and manage_selinux variables
   hosts: all
   vars_files: vars/main.yml
   vars:
-    ha_cluster_export_configuration: true
     ha_cluster_cluster_name: test-cluster
-    ha_cluster_transport:
-      crypto:
-        - name: cipher
-          value: none
-        - name: hash
-          value: none
+    ha_cluster_export_configuration: true
+    ha_cluster_manage_firewall: true
+    ha_cluster_manage_selinux: true
 
   tasks:
     - name: Run test
@@ -22,40 +24,17 @@
             name: linux-system-roles.ha_cluster
             tasks_from: test_setup.yml
 
+        - name: Ensure required packages are installed
+          package:
+            name:
+              - firewalld
+              - python3-firewall
+            state: present
+
         - name: Run HA Cluster role
           include_role:
             name: linux-system-roles.ha_cluster
             public: true
-
-        - name: Fetch cluster versions of cluster components
-          include_tasks: tasks/fetch_versions.yml
-
-        - name: Check corosync
-          include_tasks: tasks/assert_corosync_config.yml
-          vars:
-            # noqa jinja[spacing]
-            __test_expected_lines:
-              - 'totem {'
-              - '    version: 2'
-              - '    cluster_name: {{ ha_cluster_cluster_name }}'
-              - '    transport: knet'
-              - '    crypto_cipher: none'
-              - '    crypto_hash: none'
-              - '}'
-              - 'nodelist {'
-              - '}'
-              - 'quorum {'
-              - '    provider: corosync_votequorum'
-              - "{{ (ansible_play_hosts_all | length == 2) | ternary(
-                '    two_node: 1',
-                '') }}"
-              - '}'
-              - 'logging {'
-              - '    to_logfile: yes'
-              - '    logfile: /var/log/cluster/corosync.log'
-              - '    to_syslog: yes'
-              - '    timestamp: on'
-              - '}'
 
         - name: Check cluster status
           include_tasks: tasks/assert_cluster_running.yml
@@ -70,27 +49,29 @@
                 ha_cluster_facts | combine({
                   'ha_cluster_enable_repos': 'it depends on test environment',
                   'ha_cluster_enable_repos_resilient_storage': 'it depends on test environment',
-                  'ha_cluster_manage_firewall': 'it depends on test environment',
-                  'ha_cluster_manage_selinux': 'it depends on test environment',
                   'ha_cluster_install_cloud_agents': 'it depends on test environment',
                   'ha_cluster_node_options': 'it depends on test environment'
                 })
               }}
             __test_expected_config:
               ha_cluster_cluster_present: true
+              ha_cluster_manage_firewall: true
+              ha_cluster_manage_selinux: true
               ha_cluster_cluster_name: test-cluster
               ha_cluster_start_on_boot: true
               ha_cluster_transport:
                 type: knet
-                crypto: "{{ ha_cluster_transport.crypto }}"
+                crypto:
+                  - name: cipher
+                    value: aes256
+                  - name: hash
+                    value: sha256
               ha_cluster_pcs_permission_list:
                 - name: haclient
                   type: group
                   allow_list: ["grant", "read", "write"]
               ha_cluster_enable_repos: "it depends on test environment"
               ha_cluster_enable_repos_resilient_storage: "it depends on test environment"
-              ha_cluster_manage_firewall: "it depends on test environment"
-              ha_cluster_manage_selinux: "it depends on test environment"
               ha_cluster_install_cloud_agents: "it depends on test environment"
               ha_cluster_node_options: "it depends on test environment"
           block:

--- a/tests/tests_pcs_permissions.yml
+++ b/tests/tests_pcs_permissions.yml
@@ -1,11 +1,26 @@
 # SPDX-License-Identifier: MIT
 ---
-- name: Minimal cluster configuration, daemons disabled
+- name: Configure pcsd permissions
   hosts: all
   vars_files: vars/main.yml
   vars:
-    ha_cluster_cluster_name: test-cluster
-    ha_cluster_start_on_boot: false
+    ha_cluster_cluster_present: true
+    ha_cluster_pcs_permission_list:
+      - type: group
+        name: haclient
+        allow_list:
+          - grant
+          - read
+          - write
+      - type: user
+        name: full_access
+        allow_list:
+          - full
+      - type: group
+        name: operator
+        allow_list:
+          - read
+          - write
     ha_cluster_export_configuration: true
 
   tasks:
@@ -22,22 +37,6 @@
             name: linux-system-roles.ha_cluster
             public: true
 
-        - name: Get services status
-          service_facts:
-
-        - name: Check services status
-          assert:
-            that:
-              - ansible_facts.services["pcsd.service"].status == "enabled"
-              - ansible_facts.services["corosync.service"].status == "disabled"
-              - ansible_facts.services["pacemaker.service"].status == "disabled"
-
-        - name: Assert cluster status
-          include_tasks: tasks/assert_cluster_running.yml
-
-        - name: Check firewall and selinux state
-          include_tasks: tasks/check_firewall_selinux.yml
-
         - name: Check exported configuration
           vars:
             __test_exported_config: >
@@ -51,8 +50,8 @@
               }}
             __test_expected_config:
               ha_cluster_cluster_present: true
-              ha_cluster_cluster_name: test-cluster
-              ha_cluster_start_on_boot: false
+              ha_cluster_cluster_name: my-cluster
+              ha_cluster_start_on_boot: true
               ha_cluster_transport:
                 type: knet
                 crypto:
@@ -60,10 +59,7 @@
                     value: aes256
                   - name: hash
                     value: sha256
-              ha_cluster_pcs_permission_list:
-                - name: haclient
-                  type: group
-                  allow_list: ["grant", "read", "write"]
+              ha_cluster_pcs_permission_list: "{{ ha_cluster_pcs_permission_list }}"
               ha_cluster_enable_repos: "it depends on test environment"
               ha_cluster_enable_repos_resilient_storage: "it depends on test environment"
               ha_cluster_install_cloud_agents: "it depends on test environment"

--- a/tests/tests_pcs_permissions.yml
+++ b/tests/tests_pcs_permissions.yml
@@ -44,6 +44,8 @@
                 ha_cluster_facts | combine({
                   'ha_cluster_enable_repos': 'it depends on test environment',
                   'ha_cluster_enable_repos_resilient_storage': 'it depends on test environment',
+                  'ha_cluster_manage_firewall': 'it depends on test environment',
+                  'ha_cluster_manage_selinux': 'it depends on test environment',
                   'ha_cluster_install_cloud_agents': 'it depends on test environment',
                   'ha_cluster_node_options': 'it depends on test environment'
                 })
@@ -62,6 +64,8 @@
               ha_cluster_pcs_permission_list: "{{ ha_cluster_pcs_permission_list }}"
               ha_cluster_enable_repos: "it depends on test environment"
               ha_cluster_enable_repos_resilient_storage: "it depends on test environment"
+              ha_cluster_manage_firewall: "it depends on test environment"
+              ha_cluster_manage_selinux: "it depends on test environment"
               ha_cluster_install_cloud_agents: "it depends on test environment"
               ha_cluster_node_options: "it depends on test environment"
           block:

--- a/tests/unit/firewall_mock.py
+++ b/tests/unit/firewall_mock.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2025 Red Hat, Inc.
+# Author: Tomas Jelinek <tojeline@redhat.com>
+# SPDX-License-Identifier: MIT
+
+from typing import List, Tuple
+from unittest.mock import Mock
+
+
+def get_fw_mock(
+    services: List[str], ports: List[Tuple[str, str]], exception: bool = False
+) -> Mock:
+    """
+    Provide FirewallClient mock including inner structure
+    """
+    zone_settings_mock = Mock(spec=["getServices", "getPorts"])
+    zone_settings_mock.getServices.return_value = services
+    zone_settings_mock.getPorts.return_value = ports
+
+    zone_mock = Mock(spec=["getSettings"])
+    zone_mock.getSettings.return_value = zone_settings_mock
+    if exception:
+        zone_mock.getSettings.side_effect = Exception
+
+    service_settings_mock = Mock(spec=["getPorts"])
+    service_settings_mock.getPorts.return_value = [
+        ("2224", "tcp"),
+        ("3121", "tcp"),
+        ("5403", "tcp"),
+        ("5404", "udp"),
+        ("5405-5412", "udp"),
+        ("9929", "tcp"),
+        ("9929", "udp"),
+        ("21064", "tcp"),
+    ]
+
+    service_mock = Mock(spec=["getSettings"])
+    service_mock.getSettings.return_value = service_settings_mock
+    if exception:
+        service_mock.getSettings.side_effect = Exception
+
+    config_mock = Mock(spec=["getZoneByName", "getServiceByName"])
+    config_mock.getZoneByName.return_value = zone_mock
+    config_mock.getServiceByName.return_value = service_mock
+
+    fw_mock = Mock(spec=["config", "getDefaultZone"])
+    fw_mock.getDefaultZone.return_value = "myzone"
+    fw_mock.config.return_value = config_mock
+
+    return fw_mock

--- a/tests/unit/test_ha_cluster_info.py
+++ b/tests/unit/test_ha_cluster_info.py
@@ -279,7 +279,6 @@ class ExportOsConfiguration(TestCase):
         self.assert_rhel_export(
             [
                 (0, dnf_repolist, ""),
-                (0, dnf_repolist, ""),
                 (0, rpm_packages, ""),
             ],
             {
@@ -308,7 +307,6 @@ class ExportOsConfiguration(TestCase):
         self.assert_rhel_export(
             [
                 (0, dnf_repolist, ""),
-                (0, dnf_repolist, ""),
                 (0, rpm_packages, ""),
             ],
             {
@@ -319,17 +317,41 @@ class ExportOsConfiguration(TestCase):
         )
 
     @mock.patch("ha_cluster_info.loader.is_rhel_or_clone", lambda: True)
-    def test_rhel_errors(self) -> None:
+    def test_rhel_error_repolist(self) -> None:
+        rpm_packages = dedent(
+            """\
+            package1
+            resource-agents-cloud
+            package2
+            """
+        )
         self.assert_rhel_export(
             [
                 (1, "some output", "an error"),
-                (1, "some output", "an error"),
+                (0, rpm_packages, ""),
+            ],
+            {
+                "ha_cluster_install_cloud_agents": True,
+            },
+        )
+
+    @mock.patch("ha_cluster_info.loader.is_rhel_or_clone", lambda: True)
+    def test_rhel_error_pkglist(self) -> None:
+        dnf_repolist = dedent(
+            """\
+            repo1id           Repository 1
+            highavailability  Repository HA Addon
+            repo2id           Repository 2
+            """
+        )
+        self.assert_rhel_export(
+            [
+                (0, dnf_repolist, ""),
                 (1, "some output", "an error"),
             ],
             {
-                "ha_cluster_enable_repos": False,
+                "ha_cluster_enable_repos": True,
                 "ha_cluster_enable_repos_resilient_storage": False,
-                "ha_cluster_install_cloud_agents": False,
             },
         )
 

--- a/tests/unit/test_info_exporter.py
+++ b/tests/unit/test_info_exporter.py
@@ -106,6 +106,61 @@ class ExportInstallCloudAgents(TestCase):
         self.assertTrue(exporter.export_install_cloud_agents(rpm_packages))
 
 
+class ExportManageFirewall(TestCase):
+    def test_true_by_service(self) -> None:
+        self.assertTrue(
+            exporter.export_manage_firewall(
+                {
+                    "services": ["service1", "high-availability"],
+                    "ports": [],
+                }
+            )
+        )
+
+    def test_true_by_port(self) -> None:
+        self.assertTrue(
+            exporter.export_manage_firewall(
+                {
+                    "services": ["service1"],
+                    "ports": [("1229", "tcp")],
+                }
+            )
+        )
+
+    def test_false(self) -> None:
+        self.assertFalse(
+            exporter.export_manage_firewall(
+                {
+                    "services": ["service1", "availability"],
+                    "ports": [("1229", "udp")],
+                }
+            )
+        )
+
+
+class ExportManageSelinux(TestCase):
+    def test_true_by_tcp(self) -> None:
+        firewall_ports = [("3456", "tcp"), ("45670", "udp")]
+        selinux_ports = (["2345", "3456"], ["4567", "5678"])
+        self.assertTrue(
+            exporter.export_manage_selinux(firewall_ports, selinux_ports)
+        )
+
+    def test_true_by_udp(self) -> None:
+        firewall_ports = [("34560", "tcp"), ("4567", "udp")]
+        selinux_ports = (["2345", "3456"], ["4567", "5678"])
+        self.assertTrue(
+            exporter.export_manage_selinux(firewall_ports, selinux_ports)
+        )
+
+    def test_false(self) -> None:
+        firewall_ports = [("34560", "tcp"), ("45670", "udp")]
+        selinux_ports = (["2345", "3456"], ["4567", "5678"])
+        self.assertFalse(
+            exporter.export_manage_selinux(firewall_ports, selinux_ports)
+        )
+
+
 class ExportStartOnBoot(TestCase):
     def test_main(self) -> None:
         self.assertFalse(exporter.export_start_on_boot(False, False))

--- a/tests/unit/test_info_exporter.py
+++ b/tests/unit/test_info_exporter.py
@@ -9,6 +9,7 @@
 
 import sys
 from importlib import import_module
+from textwrap import dedent
 from typing import Any, Dict
 from unittest import TestCase
 
@@ -38,6 +39,71 @@ class DictToNvList(TestCase):
             exporter._dict_to_nv_list(dict(one="1", two="2")),
             [dict(name="one", value="1"), dict(name="two", value="2")],
         )
+
+
+class ExportEnableReposHa(TestCase):
+    def test_enabled(self) -> None:
+        # pylint: disable=line-too-long
+        dnf_repolist = dedent(
+            """\
+            Updating Subscription Management repositories.
+            repo id                                  repo name
+            rhel-10-for-x86_64-appstream-rpms        Red Hat Enterprise Linux 10 for x86_64 - AppStream (RPMs)
+            rhel-10-for-x86_64-baseos-rpms           Red Hat Enterprise Linux 10 for x86_64 - BaseOS (RPMs)
+            rhel-10-for-x86_64-highavailability-rpms Red Hat Enterprise Linux 10 for x86_64 - High Availability (RPMs)
+            """
+        )
+        self.assertTrue(exporter.export_enable_repos_ha(dnf_repolist))
+
+    def test_not_enabled(self) -> None:
+        dnf_repolist = dedent(
+            """\
+            repo id                repo name
+            fedora                 Fedora 41 - x86_64
+            fedora-cisco-openh264  Fedora 41 openh264 (From Cisco) - x86_64
+            updates                Fedora 41 - x86_64 - Updates
+            """
+        )
+        self.assertFalse(exporter.export_enable_repos_ha(dnf_repolist))
+
+
+class ExportEnableReposRs(TestCase):
+    def test_enabled(self) -> None:
+        # pylint: disable=line-too-long
+        dnf_repolist = dedent(
+            """\
+            Updating Subscription Management repositories.
+            repo id                                  repo name
+            rhel-9-for-x86_64-appstream-rpms         Red Hat Enterprise Linux 9 for x86_64 - AppStream (RPMs)
+            rhel-9-for-x86_64-baseos-rpms            Red Hat Enterprise Linux 9 for x86_64 - BaseOS (RPMs)
+            rhel-9-for-x86_64-highavailability-rpms  Red Hat Enterprise Linux 9 for x86_64 - High Availability (RPMs)
+            rhel-9-for-x86_64-resilientstorage-rpms  Red Hat Enterprise Linux 9 for x86_64 - Resilient Storage (RPMs)
+            """
+        )
+        self.assertTrue(exporter.export_enable_repos_rs(dnf_repolist))
+
+    def test_not_enabled(self) -> None:
+        # pylint: disable=line-too-long
+        dnf_repolist = dedent(
+            """\
+            Updating Subscription Management repositories.
+            repo id                                  repo name
+            rhel-10-for-x86_64-appstream-rpms        Red Hat Enterprise Linux 10 for x86_64 - AppStream (RPMs)
+            rhel-10-for-x86_64-baseos-rpms           Red Hat Enterprise Linux 10 for x86_64 - BaseOS (RPMs)
+            rhel-10-for-x86_64-highavailability-rpms Red Hat Enterprise Linux 10 for x86_64 - High Availability (RPMs)
+            """
+        )
+        self.assertFalse(exporter.export_enable_repos_rs(dnf_repolist))
+
+
+class ExportInstallCloudAgents(TestCase):
+    def test_not_installed(self) -> None:
+        rpm_packages = ["package1", "package2"]
+        self.assertFalse(exporter.export_install_cloud_agents(rpm_packages))
+
+    def test_installed(self) -> None:
+        rpm_packages = ["package1", "package2", "resource-agents-cloud"]
+        self.assertTrue(exporter.export_install_cloud_agents(rpm_packages))
 
 
 class ExportStartOnBoot(TestCase):

--- a/tests/unit/test_info_loader.py
+++ b/tests/unit/test_info_loader.py
@@ -10,13 +10,148 @@
 import json
 import sys
 from importlib import import_module
+from textwrap import dedent
 from unittest import TestCase, mock
 
 sys.modules["ansible.module_utils.ha_cluster_lsr"] = import_module(
     "ha_cluster_lsr"
 )
 
+from typing import Any, List
+
 from ha_cluster_lsr.info import loader
+
+
+class IsRhelOrClone(TestCase):
+    file_path = "/etc/os-release"
+
+    def _assert_is_rhel(self, mock_data: str, is_rhel: bool) -> None:
+        with mock.patch(
+            "ha_cluster_lsr.info.loader.open",
+            mock.mock_open(read_data=mock_data),
+        ) as mock_open:
+            self.assertEqual(loader.is_rhel_or_clone(), is_rhel)
+            mock_open.assert_called_once_with(
+                self.file_path, "r", encoding="utf-8", errors="replace"
+            )
+
+    def test_is_rhel(self) -> None:
+        platform_list = [
+            "platform:el8",
+            "platform:el9",
+            "platform:el10",
+        ]
+        for platform in platform_list:
+            with self.subTest(platform=platform):
+                mock_data = f'PLATFORM_ID="{platform}"\n'
+                self._assert_is_rhel(mock_data, True)
+
+    def test_is_not_rhel(self) -> None:
+        platform_list = [
+            "platform:f42",
+            "",
+        ]
+        for platform in platform_list:
+            with self.subTest(platform=platform):
+                mock_data = f'PLATFORM_ID="{platform}"\n'
+                self._assert_is_rhel(mock_data, False)
+
+    def test_missing_platform_id_line(self) -> None:
+        mock_data = 'NAME="Debian GNU/Linux"\nID=debian\n'
+        self._assert_is_rhel(mock_data, False)
+
+    def test_unable_to_read_os_release_file(self) -> None:
+        with mock.patch(
+            "ha_cluster_lsr.info.loader.open",
+            mock.mock_open(),
+        ) as mock_open:
+            mock_open.side_effect = FileNotFoundError
+            self.assertEqual(loader.is_rhel_or_clone(), False)
+
+
+class IsRhelRepoEnabled(TestCase):
+    def test_enabled(self) -> None:
+        # pylint: disable=line-too-long
+        dnf_output = dedent(
+            """\
+            Updating Subscription Management repositories.
+            repo id                                  repo name
+            rhel-10-for-x86_64-appstream-rpms        Red Hat Enterprise Linux 10 for x86_64 - AppStream (RPMs)
+            rhel-10-for-x86_64-baseos-rpms           Red Hat Enterprise Linux 10 for x86_64 - BaseOS (RPMs)
+            rhel-10-for-x86_64-highavailability-rpms Red Hat Enterprise Linux 10 for x86_64 - High Availability (RPMs)
+            """
+        )
+        runner_mock = mock.Mock()
+        runner_mock.return_value = (0, dnf_output, "")
+        self.assertTrue(
+            loader.is_rhel_repo_enabled(
+                runner_mock, ("HighAvailability", "highavailability")
+            )
+        )
+        runner_mock.assert_called_once_with(["dnf", "repolist"], {})
+
+    def test_not_enabled(self) -> None:
+        dnf_output = dedent(
+            """\
+            repo id                repo name
+            fedora                 Fedora 41 - x86_64
+            fedora-cisco-openh264  Fedora 41 openh264 (From Cisco) - x86_64
+            updates                Fedora 41 - x86_64 - Updates
+            """
+        )
+        runner_mock = mock.Mock()
+        runner_mock.return_value = (0, dnf_output, "")
+        self.assertFalse(
+            loader.is_rhel_repo_enabled(
+                runner_mock, ("HighAvailability", "highavailability")
+            )
+        )
+        runner_mock.assert_called_once_with(["dnf", "repolist"], {})
+
+    def test_dnf_error(self) -> None:
+        runner_mock = mock.Mock()
+        runner_mock.return_value = (1, "", "an error")
+        self.assertFalse(
+            loader.is_rhel_repo_enabled(
+                runner_mock, ("HighAvailability", "highavailability")
+            )
+        )
+        runner_mock.assert_called_once_with(["dnf", "repolist"], {})
+
+
+class ListRhelInstalledPackages(TestCase):
+    def _assert_packages(
+        self, runner_mock: Any, expected_packages: List[str]
+    ) -> None:
+        self.assertEqual(
+            loader.list_rhel_installed_packages(runner_mock),
+            expected_packages,
+        )
+        runner_mock.assert_called_once_with(
+            ["rpm", "--query", "--all", "--queryformat", "%{NAME}\\n"], {}
+        )
+
+    def test_success(self) -> None:
+        package_list = [
+            "package_1",
+            "package_2",
+            "package_3",
+        ]
+        rpm_output = "\n".join(package_list)
+        runner_mock = mock.Mock()
+        runner_mock.return_value = (0, rpm_output, "")
+        self._assert_packages(runner_mock, package_list)
+
+    def test_rpm_error(self) -> None:
+        package_list = [
+            "package_1",
+            "package_2",
+            "package_3",
+        ]
+        rpm_output = "\n".join(package_list)
+        runner_mock = mock.Mock()
+        runner_mock.return_value = (1, rpm_output, "an error")
+        self._assert_packages(runner_mock, [])
 
 
 class IsServiceEnabled(TestCase):
@@ -246,6 +381,110 @@ class GetPcsdKnownHosts(TestCase):
                     node7="[2001:db8::7]:10007",
                     node8="192.0.2.8:10008",
                 ),
+            )
+            mock_open.assert_called_once_with(
+                self.file_path, "r", encoding="utf-8"
+            )
+        mock_exists.assert_called_once_with(self.file_path)
+
+
+class GetPcsdLocalClusterPermissions(TestCase):
+    file_path = "/var/lib/pcsd/pcs_settings.conf"
+
+    @mock.patch("ha_cluster_lsr.info.loader.os.path.exists")
+    def test_file_not_present(self, mock_exists: mock.Mock) -> None:
+        mock_exists.return_value = False
+        self.assertEqual(loader.get_pcsd_local_cluster_permissions(), None)
+        mock_exists.assert_called_once_with(self.file_path)
+
+    @mock.patch("ha_cluster_lsr.info.loader.os.path.exists")
+    def test_json_error(self, mock_exists: mock.Mock) -> None:
+        mock_exists.return_value = True
+        mock_data = "not a json"
+        with mock.patch(
+            "ha_cluster_lsr.info.loader.open",
+            mock.mock_open(read_data=mock_data),
+        ) as mock_open:
+            with self.assertRaises(loader.JsonParseError) as cm:
+                loader.get_pcsd_local_cluster_permissions()
+            self.assertEqual(
+                cm.exception.kwargs,
+                dict(
+                    data="not logging data",
+                    data_desc="pcsd settings",
+                    error="Expecting value: line 1 column 1 (char 0)",
+                    additional_info=None,
+                ),
+            )
+            mock_open.assert_called_once_with(
+                self.file_path, "r", encoding="utf-8"
+            )
+        mock_exists.assert_called_once_with(self.file_path)
+
+    @mock.patch("ha_cluster_lsr.info.loader.os.path.exists")
+    def test_json_missing_key_or_bad_value(
+        self, mock_exists: mock.Mock
+    ) -> None:
+        mock_exists.return_value = True
+        mock_data_list = [
+            "{}",
+            '{"permissions": {}}',
+            '{"permissions": "foobar"}',
+            '{"permissions": {"local_cluster": []}}',
+            '{"permissions": {"local_cluster": null}}',
+        ]
+        for mock_data in mock_data_list:
+            with self.subTest(mock_data=mock_data):
+                mock_exists.reset_mock()
+                with mock.patch(
+                    "ha_cluster_lsr.info.loader.open",
+                    mock.mock_open(read_data=mock_data),
+                ) as mock_open:
+                    self.assertEqual(
+                        loader.get_pcsd_local_cluster_permissions(),
+                        [],
+                    )
+                    mock_open.assert_called_once_with(
+                        self.file_path, "r", encoding="utf-8"
+                    )
+                mock_exists.assert_called_once_with(self.file_path)
+
+    @mock.patch("ha_cluster_lsr.info.loader.os.path.exists")
+    def test_json_extract_permission(self, mock_exists: mock.Mock) -> None:
+        mock_exists.return_value = True
+        mock_data = """
+            {
+                "permissions": {
+                    "local_cluster": [
+                        {},
+                        {"name": "test1"},
+                        {"name": "test2", "type": "user"},
+                        {"type": "group"},
+                        {"name": "test3", "allow": ["read"]},
+                        {"type": "group", "allow": ["write"]},
+                        {"name": "test4", "type": "user", "allow": []},
+                        {"name": "test5", "type": "user", "allow": ["write"]},
+                        {"name": "test6", "type": "group", "allow": ["write", "grant"]},
+                        {"name": "test7", "type": "group", "allow": null}
+                    ]
+                }
+            }
+        """
+        with mock.patch(
+            "ha_cluster_lsr.info.loader.open",
+            mock.mock_open(read_data=mock_data),
+        ) as mock_open:
+            self.assertEqual(
+                loader.get_pcsd_local_cluster_permissions(),
+                [
+                    {"name": "test4", "type": "user", "allow_list": []},
+                    {"name": "test5", "type": "user", "allow_list": ["write"]},
+                    {
+                        "name": "test6",
+                        "type": "group",
+                        "allow_list": ["write", "grant"],
+                    },
+                ],
             )
             mock_open.assert_called_once_with(
                 self.file_path, "r", encoding="utf-8"

--- a/vars/CentOS_10.yml
+++ b/vars/CentOS_10.yml
@@ -9,6 +9,7 @@ __ha_cluster_repos:
   - id: highavailability
     name: HighAvailability
 
+# cloud agent packages are also mentioned in library/ha_cluster_info.py
 __ha_cluster_cloud_agents_packages:
   x86_64:
     - resource-agents-cloud

--- a/vars/CentOS_8.yml
+++ b/vars/CentOS_8.yml
@@ -11,6 +11,7 @@ __ha_cluster_repos:
   - id: resilientstorage
     name: ResilientStorage
 
+# cloud agent packages are also mentioned in library/ha_cluster_info.py
 __ha_cluster_cloud_agents_packages:
   x86_64:
     - resource-agents-aliyun

--- a/vars/CentOS_9.yml
+++ b/vars/CentOS_9.yml
@@ -11,6 +11,7 @@ __ha_cluster_repos:
   - id: resilientstorage
     name: ResilientStorage
 
+# cloud agent packages are also mentioned in library/ha_cluster_info.py
 __ha_cluster_cloud_agents_packages:
   x86_64:
     - resource-agents-cloud

--- a/vars/RedHat_10.yml
+++ b/vars/RedHat_10.yml
@@ -9,6 +9,7 @@ __ha_cluster_repos:
   - id: rhel-10-for-{{ ansible_architecture }}-highavailability-rpms
     name: High Availability
 
+# cloud agent packages are also mentioned in library/ha_cluster_info.py
 __ha_cluster_cloud_agents_packages:
   x86_64:
     - resource-agents-cloud

--- a/vars/RedHat_8.yml
+++ b/vars/RedHat_8.yml
@@ -11,6 +11,7 @@ __ha_cluster_repos:
   - id: rhel-8-for-{{ ansible_architecture }}-resilientstorage-rpms
     name: Resilient Storage
 
+# cloud agent packages are also mentioned in library/ha_cluster_info.py
 __ha_cluster_cloud_agents_packages:
   x86_64:
     - resource-agents-aliyun

--- a/vars/RedHat_9.yml
+++ b/vars/RedHat_9.yml
@@ -11,6 +11,7 @@ __ha_cluster_repos:
   - id: rhel-9-for-{{ ansible_architecture }}-resilientstorage-rpms
     name: Resilient Storage
 
+# cloud agent packages are also mentioned in library/ha_cluster_info.py
 __ha_cluster_cloud_agents_packages:
   x86_64:
     - resource-agents-cloud


### PR DESCRIPTION
Enhancement:
Add pcsd related and OS related variables to `ha_cluster_info` module exporting current cluster configuration.

Reason:
This is the next step in implementing an info module which exports cluster configuration in a variables structure in the same format as ha_cluster role accepts.

Result:
variables have been added to the export:
* `ha_cluster_enable_repos`
* `ha_cluster_enable_repos_resilient_storage`
* `ha_cluster_manage_firewall`
* `ha_cluster_manage_selinux`
* `ha_cluster_install_cloud_agents`
* `ha_cluster_pcs_permission_list`

Issue Tracker Tickets (Jira or BZ if any):
https://issues.redhat.com/browse/RHEL-46224