### PR TITLE
fix: disable proxy when connecting to pcsd local socket

### DIFF
--- a/module_utils/ha_cluster_lsr/pcs_api_v2_utils.py
+++ b/module_utils/ha_cluster_lsr/pcs_api_v2_utils.py
@@ -214,6 +214,8 @@ def call_api_raw(
     """
     response, info = fetch_url(
         module,
+        # never use a proxy when connecting to a local unix socket (RHEL-81918)
+        use_proxy=False,
         force=True,  # do not get a cached response
         unix_socket=PCSD_SOCKET,
         url=API_ENDPOINT,


### PR DESCRIPTION
Enhancement:
Do not use proxy when connecting to local pcsd via unix socket on managed nodes.

Reason:
When a proxy is defined, it disrupts communication towards the local pcsd unix socket. This makes the role fail.

Result:
Role works even if a proxy is defined.

Issue Tracker Tickets (Jira or BZ if any):
https://issues.redhat.com/browse/RHEL-81918
