### PR TITLE
feat: crmsh remove python3-rpm dependency

### DIFF
--- a/tasks/enable-repositories/Suse.yml
+++ b/tasks/enable-repositories/Suse.yml
@@ -9,8 +9,8 @@
   when: ansible_distribution.split("_")[0] == 'SLES'
   block:
 
-    - name: Query package sle-ha-release
-      ansible.builtin.shell:
+    - name: Query package sle-ha-release  # noqa command-instead-of-module
+      ansible.builtin.command:
         cmd: rpm -q sle-ha-release
       register: __ha_cluster_sle_ha_release
       changed_when: false

--- a/tasks/enable-repositories/Suse.yml
+++ b/tasks/enable-repositories/Suse.yml
@@ -1,32 +1,40 @@
 # SPDX-License-Identifier: MIT
 ---
-# All required repositories are already part of SLES for SAP 15 SP5+.
+# All required repositories are already part of SLES for SAP Applications.
 
 # High Availability Extension (HAE) is required for cluster setup on SLES.
 # All cluster packages are present on SLES_SAP and openSUSE,
 # but not on base SLES without HAE.
-- name: Execute only on SLES
+- name: Block to assert that High Availability Extension is present on SLES
   when: ansible_distribution.split("_")[0] == 'SLES'
   block:
 
-    - name: Gather package facts
-      ansible.builtin.package_facts:
-        manager: auto
+    - name: Query package sle-ha-release
+      ansible.builtin.shell:
+        cmd: rpm -q sle-ha-release
+      register: __ha_cluster_sle_ha_release
+      changed_when: false
+      ignore_errors: true  # ignore and check /etc/products.d/ file instead
 
     - name: Check High Availability Extension presence using product file
       ansible.builtin.stat:
         path: /etc/products.d/sle-ha.prod
-      register: __ha_cluster_ha_ext_stat
+      register: __ha_cluster_sle_ha_stat
+      when: __ha_cluster_sle_ha_release.rc != 0
 
-    # Registering HA Extension creates file /etc/products.d/sle-ha.prod and
-    # installs rpm sle-ha-release. Cluster software is not installed.
+    # Registering HA Extension results in:
+    # - Created file /etc/products.d/sle-ha.prod
+    # - Installed sle-ha-release package.
+    # Cluster packages are not installed by default.
     - name: Assert that High Availability Extension is present
       ansible.builtin.assert:
         that:
-          - "'sle-ha-release' in ansible_facts.packages"
-          - __ha_cluster_ha_ext_stat.stat.exists
+          - __ha_cluster_sle_ha_release.rc == 0 or
+            (__ha_cluster_sle_ha_stat is defined
+              and __ha_cluster_sle_ha_stat.stat.exists)
         success_msg: "High Availability Extension was detected."
-        fail_msg: "High Availability Extension is not registered!
-          Register HA Extension before executing again."
+        fail_msg: |
+          High Availability Extension is not registered!
+          Register HA Extension before executing again.
       # Fatal fail will occur if any of cluster nodes is missing HAE
       any_errors_fatal: true


### PR DESCRIPTION
Enhancement:
- Removes `python3-rpm` dependency caused by `ansible.builtin.package_facts`
- Improved conditional for `/etc/products.d/sle-ha.prod` file validation to not execute if package is present.

Reason:
- Removal of unnecessary dependencies as started in https://github.com/linux-system-roles/ha_cluster/pull/249

Result:
- Tested on SLES 15 SP6 on AWS with latest `crmsh` package.
