### PR TITLE
refactor: use single line pylint disable broad-except

### DIFF
--- a/module_utils/ha_cluster_lsr/info/loader.py
+++ b/module_utils/ha_cluster_lsr/info/loader.py
@@ -161,9 +161,8 @@ def get_firewall_config(
             "services": settings.getServices(),
             "ports": settings.getPorts(),
         }
-    # pylint: disable=broad-exception-caught
     # catch any exception, firewall is not installed or not running, etc.
-    except Exception:
+    except Exception:  # pylint: disable=broad-except
         return None
 
 
@@ -182,9 +181,8 @@ def get_firewall_ha_cluster_ports(
             .getSettings()
             .getPorts()
         )
-    # pylint: disable=broad-exception-caught
     # catch any exception, firewall is not installed or not running, etc.
-    except Exception:
+    except Exception:  # pylint: disable=broad-except
         return None
 
 
@@ -202,9 +200,8 @@ def get_selinux_ha_cluster_ports(
             all_ports.get(("cluster_port_t", "tcp"), []),
             all_ports.get(("cluster_port_t", "udp"), []),
         )
-    # pylint: disable=broad-exception-caught
     # catch any exception, selinux not available, etc.
-    except Exception:
+    except Exception:  # pylint: disable=broad-except
         return None
 
 


### PR DESCRIPTION
The pylint used by ansible-test doesn't like broad-exception-caught

```
ERROR: plugins/module_utils/ha_cluster_lsr/info/loader.py:164:0: unknown-option-value: Unknown option value for 'disable', expected a valid pylint message and got 'broad-exception-caught'
ERROR: plugins/module_utils/ha_cluster_lsr/info/loader.py:185:0: unknown-option-value: Unknown option value for 'disable', expected a valid pylint message and got 'broad-exception-caught'
ERROR: plugins/module_utils/ha_cluster_lsr/info/loader.py:205:0: unknown-option-value: Unknown option value for 'disable', expected a valid pylint message and got 'broad-exception-caught'
```

Instead use the newer `broad-except` and use it inline for the single line.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
