### PR TITLE
feat: crmsh SLES 16 changes and introduction of zypper patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,10 @@ boolean, default: `false`
 If set to `true`, all packages will be installed with latest version.
 If set to `false`, existing packages will not be updated.
 
+#### `ha_cluster_patterns`
+
+SUSE Specific, list of additional zypper patterns to be installed, default: no patterns
+
 #### `ha_cluster_hacluster_password`
 
 string, no default - must be specified

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ An Ansible role for managing High Availability Clustering.
 
 * Compatible OS
   * RHEL 8.3+, Fedora 31+
-  * SUSE Linux Enterprise Server 15 with HA extension
-  * SUSE Linux Enterprise Server for SAP Applications 15
+  * SUSE Linux Enterprise Server 15 and 16 with HA extension
+  * SUSE Linux Enterprise Server for SAP Applications 15 and 16
 * Systems running RHEL are expected to be registered and have High-Availability
   repositories accessible, and ResilientStorage repositories accessible if using
   `ha_cluster_enable_repos_resilient_storage`
@@ -166,16 +166,16 @@ It is possible to specify fence agents here as well. However,
 [`ha_cluster_fence_agent_packages`](#ha_cluster_fence_agent_packages) is
 preferred for that, so that its default value is overridden.
 
+#### `ha_cluster_zypper_patterns`
+
+SUSE Specific, list of additional zypper patterns to be installed, default: no patterns
+
 #### `ha_cluster_use_latest_packages`
 
 boolean, default: `false`
 
 If set to `true`, all packages will be installed with latest version.
 If set to `false`, existing packages will not be updated.
-
-#### `ha_cluster_patterns`
-
-SUSE Specific, list of additional zypper patterns to be installed, default: no patterns
 
 #### `ha_cluster_hacluster_password`
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,11 +13,12 @@ ha_cluster_start_on_boot: true
 
 ha_cluster_install_cloud_agents: false
 ha_cluster_extra_packages: []
+# SUSE Specific, list of additional zypper patterns to be installed
+ha_cluster_zypper_patterns: []
 # Default fence agent packages are defined in respective os_family var files
 ha_cluster_fence_agent_packages:
   "{{ __ha_cluster_fence_agent_packages_default }}"
 ha_cluster_use_latest_packages: false
-ha_cluster_patterns: []
 
 ha_cluster_hacluster_password: ""
 ha_cluster_regenerate_keys: false
@@ -78,3 +79,8 @@ ha_cluster_qnetd:
   start_on_boot: true
 
 ha_cluster_export_configuration: false
+
+# SUSE Specific, name and group of os user for cluster administration.
+# This allows cluster administration with non-root user.
+# ha_cluster_admin_user_name: ''
+# ha_cluster_admin_user_group: ''

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,7 @@ ha_cluster_extra_packages: []
 ha_cluster_fence_agent_packages:
   "{{ __ha_cluster_fence_agent_packages_default }}"
 ha_cluster_use_latest_packages: false
+ha_cluster_patterns: []
 
 ha_cluster_hacluster_password: ""
 ha_cluster_regenerate_keys: false

--- a/tasks/enable-repositories/Suse.yml
+++ b/tasks/enable-repositories/Suse.yml
@@ -6,7 +6,7 @@
 # All cluster packages are present on SLES_SAP and openSUSE,
 # but not on base SLES without HAE.
 - name: Block to assert that High Availability Extension is present on SLES
-  when: ansible_distribution.split("_")[0] == 'SLES'
+  when: ansible_distribution == 'SLES'
   block:
 
     - name: Query package sle-ha-release  # noqa command-instead-of-module
@@ -38,3 +38,25 @@
           Register HA Extension before executing again.
       # Fatal fail will occur if any of cluster nodes is missing HAE
       any_errors_fatal: true
+
+
+# Install zypper patterns before additional package installation
+# Pattern installation will run only if pattern is not installed
+# This ensures that command module shows correct changed status
+- name: Query installed zypper patterns
+  ansible.builtin.command:
+    cmd: zypper patterns --installed-only
+  register: __ha_cluster_installed_patterns
+  changed_when: false
+  ignore_errors: true
+
+- name: Ensure that the required zypper patterns are installed
+  ansible.builtin.command:
+    cmd: zypper install -y -t pattern {{ item }}
+  loop: "{{ (ha_cluster_patterns | list | d([])
+    + __ha_cluster_patterns | list | d([])) | unique }}"
+  # Retry added to handle post scripts problems like RC 107
+  retries: 2
+  delay: 10
+  when: item not in __ha_cluster_installed_patterns.stdout
+  changed_when: item not in __ha_cluster_installed_patterns.stdout

--- a/tasks/enable-repositories/Suse.yml
+++ b/tasks/enable-repositories/Suse.yml
@@ -53,8 +53,8 @@
 - name: Ensure that the required zypper patterns are installed
   ansible.builtin.command:
     cmd: zypper install -y -t pattern {{ item }}
-  loop: "{{ (ha_cluster_patterns | list | d([])
-    + __ha_cluster_patterns | list | d([])) | unique }}"
+  loop: "{{ (ha_cluster_zypper_patterns | list | d([])
+    + __ha_cluster_zypper_patterns | list | d([])) | unique }}"
   # Retry added to handle post scripts problems like RC 107
   retries: 2
   delay: 10

--- a/tasks/shell_crmsh/check-and-prepare-role-variables.yml
+++ b/tasks/shell_crmsh/check-and-prepare-role-variables.yml
@@ -1,5 +1,49 @@
 # SPDX-License-Identifier: MIT
 ---
+- name: Discover cluster node names
+  ansible.builtin.set_fact:
+    __ha_cluster_node_name: "{{ ha_cluster.node_name | d(inventory_hostname) }}"
+
+- name: Collect cluster node names
+  ansible.builtin.set_fact:
+    __ha_cluster_all_node_names: "{{
+        ansible_play_hosts
+        | map('extract', hostvars, '__ha_cluster_node_name')
+        | list
+      }}"
+
+- name: Check ha_cluster_node_options
+  run_once: true
+  vars:
+    __nodes_from_options: "{{
+      ha_cluster_node_options | map(attribute='node_name') | list }}"
+  block:
+    - name: >
+        Fail if ha_cluster_node_options contains unknown or duplicate nodes
+      ansible.builtin.fail:
+        msg: >
+          node_name fields in ha_cluster_node_options must be unique
+          and they must match cluster nodes
+      when:
+        - >
+          (
+            __nodes_from_options != (__nodes_from_options | unique)
+          ) or (
+            __nodes_from_options | difference(__ha_cluster_all_node_names)
+          )
+
+- name: Extract node options
+  ansible.builtin.set_fact:
+    __ha_cluster_local_node: >-
+      {{
+        (ha_cluster | d({})) | combine(
+          (ha_cluster_node_options | d([]))
+          | selectattr('node_name', 'match', '^' ~ __ha_cluster_node_name ~ '$')
+          | list | last | d({})
+        )
+      }}
+
+
 - name: Check cluster configuration variables
   block:
     - name: Fail if passwords are not specified
@@ -16,11 +60,12 @@
       ansible.builtin.fail:
         msg: All nodes must have the same number of SBD devices specified
       when:
-        - ha_cluster_cluster_present | bool
-        - ha_cluster_sbd_enabled | bool
+        - ha_cluster_cluster_present
+        - ha_cluster_sbd_enabled
         - >
           ansible_play_hosts
-          | map('extract', hostvars, ['ha_cluster', 'sbd_devices'])
+          | map('extract', hostvars,
+            ['__ha_cluster_local_node', 'sbd_devices'])
           | map('default', [], true)
           | map('length') | unique | length > 1
       run_once: true
@@ -59,17 +104,6 @@
       loop: "{{ ha_cluster_stonith_levels }}"
       run_once: true
 
-- name: Discover cluster node names
-  ansible.builtin.set_fact:
-    __ha_cluster_node_name: "{{ ha_cluster.node_name | d(inventory_hostname) }}"
-
-- name: Collect cluster node names
-  ansible.builtin.set_fact:
-    __ha_cluster_all_node_names: "{{
-        ansible_play_hosts
-        | map('extract', hostvars, '__ha_cluster_node_name')
-        | list
-      }}"
 
 - name: Extract qdevice settings
   ansible.builtin.set_fact:
@@ -98,7 +132,7 @@
     # - qdevice is not used
     __ha_cluster_sbd_needs_atb: "{{
         ha_cluster_sbd_enabled
-        and not ha_cluster.sbd_devices | d([])
+        and not __ha_cluster_local_node.sbd_devices | d([])
         and __ha_cluster_all_node_names | length is even
         and not __ha_cluster_qdevice_in_use
       }}"

--- a/tasks/shell_crmsh/cluster-auth.yml
+++ b/tasks/shell_crmsh/cluster-auth.yml
@@ -23,7 +23,7 @@
       if ha_cluster_admin_user_group is defined
         and ha_cluster_admin_user_group | length > 0
       else ha_cluster_admin_user_name }}"
-  block: 
+  block:
 
     - name: Ensure that the group exists '{{ __ha_cluster_admin_user_group }}'
       ansible.builtin.group:
@@ -195,7 +195,7 @@
     group: root
   when: not __ha_cluster_crm_conf_stat.stat.exists
 
-- name: Update hosts in existing file {{ __ha_cluster_crm_conf_path }} 
+- name: Update hosts in existing file {{ __ha_cluster_crm_conf_path }}
   ansible.builtin.lineinfile:
     path: "{{ __ha_cluster_crm_conf_path }}"
     regexp: '^hosts =*'

--- a/tasks/shell_crmsh/cluster-auth.yml
+++ b/tasks/shell_crmsh/cluster-auth.yml
@@ -1,4 +1,208 @@
 # SPDX-License-Identifier: MIT
 ---
-# Placeholder for potential auth tasks for crmsh
-# There are no authentication steps for crmsh currently.
+# CRM cluster works without root SSH keys, but some commands require it.
+# Example: crm report, crm cluster start --all
+
+# Detection of user home directory can be done with getent_passwd['user'][4]
+
+- name: Set default facts for cluster authentication
+  ansible.builtin.set_fact:
+    __ha_cluster_ssh_user: root
+    __ha_cluster_ssh_group: root
+    __ha_cluster_ssh_path: /root/.ssh
+    __ha_cluster_ssh_key: id_rsa_hacluster
+    __ha_cluster_crm_conf_path: /root/.config/crm/crm.conf
+
+
+- name: Block for custom cluster administrator
+  when:
+    - ha_cluster_admin_user_name is defined
+    - ha_cluster_admin_user_name | length > 0
+  vars:
+    __ha_cluster_admin_user_group: "{{ ha_cluster_admin_user_group
+      if ha_cluster_admin_user_group is defined
+        and ha_cluster_admin_user_group | length > 0
+      else ha_cluster_admin_user_name }}"
+  block: 
+
+    - name: Ensure that the group '{{ __ha_cluster_admin_user_group }}' exists
+      ansible.builtin.group:
+        name: "{{ __ha_cluster_admin_user_group }}"
+        state: present
+
+    - name: Ensure that the user '{{ ha_cluster_admin_user_name }}' exists
+      ansible.builtin.user:
+        name: "{{ ha_cluster_admin_user_name }}"
+        comment: pacemaker cluster administrator
+        group: "{{ __ha_cluster_admin_user_group }}"
+
+    # Listed permissions are required for crm operations
+    - name: Create sudoers file for user '{{ ha_cluster_admin_user_name }}'
+      ansible.builtin.copy:
+        content: |
+          {{ ha_cluster_admin_user_name }} ALL=(ALL) NOPASSWD: \
+            /usr/sbin/crm, \
+            /usr/sbin/crm_mon, \
+            /usr/bin/true, \
+            /usr/bin/systemctl, \
+            /bin/sh
+        dest: "{{ __sudoers_path }}/90-{{
+          ha_cluster_admin_user_name}}-cluster-administrator"
+        mode: '0440'
+        owner: root
+        group: root
+        validate: 'visudo -cf %s'
+      vars:
+        __sudoers_path: >-
+          {% if (ansible_os_family == 'Suse' and
+                ansible_distribution_major_version | int > 15) %}
+          /usr/etc/sudoers.d
+          {%- else -%}
+          /etc/sudoers.d
+          {%- endif %}
+
+    - name: Set facts for user - '{{ ha_cluster_admin_user_name }}'
+      ansible.builtin.set_fact:
+        __ha_cluster_ssh_user: "{{ ha_cluster_admin_user_name }}"
+        __ha_cluster_ssh_group: "{{ __ha_cluster_admin_user_group }}"
+        __ha_cluster_ssh_path:
+          "{{ '/home/' ~ ha_cluster_admin_user_name ~ '/.ssh' }}"
+
+
+- name: Ensure .ssh directory exists on all nodes
+  ansible.builtin.file:
+    path: "{{ __ha_cluster_ssh_path }}"
+    state: directory
+    mode: '0700'
+    owner: "{{ __ha_cluster_ssh_user }}"
+    group: "{{ __ha_cluster_ssh_group }}"
+
+- name: Check if SSH key '{{ __ha_cluster_ssh_key }}' already exists
+  ansible.builtin.stat:
+    path: "{{ __ha_cluster_ssh_path }}/{{ __ha_cluster_ssh_key }}"
+  register: __ha_cluster_ssh_priv_key_stat
+
+- name: Check if public SSH key '{{ __ha_cluster_ssh_key }}.pub' already exists
+  ansible.builtin.stat:
+    path: "{{ __ha_cluster_ssh_path }}/{{ __ha_cluster_ssh_key }}.pub"
+  register: __ha_cluster_ssh_pub_key_stat
+
+- name: Generate public SSH key '{{ __ha_cluster_ssh_key }}'
+  ansible.builtin.command:
+    cmd: "ssh-keygen -t rsa -b 4096 -f {{
+      __ha_cluster_ssh_path }}/{{ __ha_cluster_ssh_key }} -N ''"
+  args:
+    creates: "{{ __ha_cluster_ssh_path }}/{{ __ha_cluster_ssh_key }}"
+  when: not __ha_cluster_ssh_priv_key_stat.stat.exists
+
+- name: Regenerate public key from private key if public key is missing
+  ansible.builtin.command: |
+    ssh-keygen -y -f {{ __ha_cluster_ssh_path }}/{{ __ha_cluster_ssh_key }} \
+      > {{ __ha_cluster_ssh_path }}/{{ __ha_cluster_ssh_key }}.pub
+  args:
+    creates: "{{ __ha_cluster_ssh_path }}/{{ __ha_cluster_ssh_key }}.pub"
+  when:
+    - __ha_cluster_ssh_priv_key_stat.stat.exists
+    - not __ha_cluster_ssh_pub_key_stat.stat.exists
+
+- name: Ensure correct permissions for the private SSH key
+  ansible.builtin.file:
+    path: "{{ __ha_cluster_ssh_path }}/{{ __ha_cluster_ssh_key }}"
+    owner: "{{ __ha_cluster_ssh_user }}"
+    group: "{{ __ha_cluster_ssh_group }}"
+    mode: '0600'
+
+- name: Ensure correct permissions for the public SSH key
+  ansible.builtin.file:
+    path: "{{ __ha_cluster_ssh_path }}/{{ __ha_cluster_ssh_key }}.pub"
+    owner: "{{ __ha_cluster_ssh_user }}"
+    group: "{{ __ha_cluster_ssh_group }}"
+    mode: '0644'
+
+- name: Slurp SSH public key '{{ __ha_cluster_ssh_key }}' from each node
+  ansible.builtin.slurp:
+    src: "{{ __ha_cluster_ssh_path }}/{{ __ha_cluster_ssh_key }}.pub"
+  register: __ha_cluster_ssh_pub_key
+
+- name: Distribute public SSH key to authorized_keys on all nodes
+  ansible.builtin.lineinfile:
+    path: "{{ __ha_cluster_ssh_path }}/authorized_keys"
+    create: true
+    owner: "{{ __ha_cluster_ssh_user }}"
+    group: "{{ __ha_cluster_ssh_group }}"
+    mode: '0600'
+    line: "{{ hostvars[item].__ha_cluster_ssh_pub_key.content | b64decode
+      | trim }} {{ item }}-pacemaker-cluster-administrator"
+    regexp: "^{{ (hostvars[item].__ha_cluster_ssh_pub_key.content | b64decode
+      | trim).split(' ')[1] }}"
+    state: present
+    insertafter: EOF
+  loop: "{{ ansible_play_hosts }}"
+  when:
+    - hostvars[item].__ha_cluster_ssh_pub_key is defined
+    - hostvars[item].__ha_cluster_ssh_pub_key.content is defined
+    - hostvars[item].__ha_cluster_ssh_pub_key.content | length > 0
+
+- name: Configure SSH config with '{{ __ha_cluster_ssh_key }}'
+  ansible.builtin.blockinfile:
+    path: "{{ __ha_cluster_ssh_path }}/config"
+    create: true
+    owner: "{{ __ha_cluster_ssh_user }}"
+    group: "{{ __ha_cluster_ssh_group }}"
+    mode: '0600'
+    marker: "# {mark} ANSIBLE MANAGED BLOCK FOR HACLUSTER SSH KEYS"
+    block: |
+      Host {{ ansible_play_hosts | join(' ') }}
+        IdentityFile {{ __ha_cluster_ssh_path }}/{{ __ha_cluster_ssh_key }}
+
+
+# Configuration file needs to be maintained.
+# File is created when running crm init and updated during crm join.
+- name: Ensure /root/.config/crm directory exists
+  ansible.builtin.file:
+    path: "/root/.config/crm"
+    state: directory
+    mode: '0700'
+    owner: root
+    group: root
+
+- name: Stat configuration file {{ __ha_cluster_crm_conf_path }}
+  ansible.builtin.stat:
+    path: "{{ __ha_cluster_crm_conf_path }}"
+  register: __ha_cluster_crm_conf_stat
+
+- name: Set fact with hosts line for {{ __ha_cluster_crm_conf_path }}
+  ansible.builtin.set_fact:
+    __ha_cluster_crm_conf_hosts:
+      "{{ ansible_play_hosts | map('regex_replace', '^(.*)$',
+        __ha_cluster_ssh_user + '@\\1') | join(', ') }}"
+
+- name: Create new configuration file {{ __ha_cluster_crm_conf_path }}
+  ansible.builtin.copy:
+    content: |
+      [core]
+      debug = false
+      force = false
+      wait = false
+      hosts = {{ __ha_cluster_crm_conf_hosts }}
+      no_generating_ssh_key = false
+
+      [color]
+      style = color
+    dest: "{{ __ha_cluster_crm_conf_path }}"
+    mode: '0644'
+    owner: root
+    group: root
+  when: not __ha_cluster_crm_conf_stat.stat.exists
+
+- name: Update hosts in existing file {{ __ha_cluster_crm_conf_path }} 
+  ansible.builtin.lineinfile:
+    path: "{{ __ha_cluster_crm_conf_path }}"
+    regexp: '^hosts =*'
+    line: "hosts = {{ __ha_cluster_crm_conf_hosts }}"
+    state: present
+    owner: root
+    group: root
+    mode: '0644'
+    backup: true
+  when: __ha_cluster_crm_conf_stat.stat.exists

--- a/tasks/shell_crmsh/cluster-auth.yml
+++ b/tasks/shell_crmsh/cluster-auth.yml
@@ -25,12 +25,12 @@
       else ha_cluster_admin_user_name }}"
   block: 
 
-    - name: Ensure that the group '{{ __ha_cluster_admin_user_group }}' exists
+    - name: Ensure that the group exists '{{ __ha_cluster_admin_user_group }}'
       ansible.builtin.group:
         name: "{{ __ha_cluster_admin_user_group }}"
         state: present
 
-    - name: Ensure that the user '{{ ha_cluster_admin_user_name }}' exists
+    - name: Ensure that the user exists '{{ ha_cluster_admin_user_name }}'
       ansible.builtin.user:
         name: "{{ ha_cluster_admin_user_name }}"
         comment: pacemaker cluster administrator
@@ -47,7 +47,7 @@
             /usr/bin/systemctl, \
             /bin/sh
         dest: "{{ __sudoers_path }}/90-{{
-          ha_cluster_admin_user_name}}-cluster-administrator"
+          ha_cluster_admin_user_name }}-cluster-administrator"
         mode: '0440'
         owner: root
         group: root
@@ -61,7 +61,7 @@
           /etc/sudoers.d
           {%- endif %}
 
-    - name: Set facts for user - '{{ ha_cluster_admin_user_name }}'
+    - name: Set facts for user '{{ ha_cluster_admin_user_name }}'
       ansible.builtin.set_fact:
         __ha_cluster_ssh_user: "{{ ha_cluster_admin_user_name }}"
         __ha_cluster_ssh_group: "{{ __ha_cluster_admin_user_group }}"
@@ -77,17 +77,17 @@
     owner: "{{ __ha_cluster_ssh_user }}"
     group: "{{ __ha_cluster_ssh_group }}"
 
-- name: Check if SSH key '{{ __ha_cluster_ssh_key }}' already exists
+- name: Check if SSH key already exists '{{ __ha_cluster_ssh_key }}'
   ansible.builtin.stat:
     path: "{{ __ha_cluster_ssh_path }}/{{ __ha_cluster_ssh_key }}"
   register: __ha_cluster_ssh_priv_key_stat
 
-- name: Check if public SSH key '{{ __ha_cluster_ssh_key }}.pub' already exists
+- name: Check if public SSH key already exists
   ansible.builtin.stat:
     path: "{{ __ha_cluster_ssh_path }}/{{ __ha_cluster_ssh_key }}.pub"
   register: __ha_cluster_ssh_pub_key_stat
 
-- name: Generate public SSH key '{{ __ha_cluster_ssh_key }}'
+- name: Generate private SSH key - '{{ __ha_cluster_ssh_key }}'
   ansible.builtin.command:
     cmd: "ssh-keygen -t rsa -b 4096 -f {{
       __ha_cluster_ssh_path }}/{{ __ha_cluster_ssh_key }} -N ''"
@@ -119,7 +119,7 @@
     group: "{{ __ha_cluster_ssh_group }}"
     mode: '0644'
 
-- name: Slurp SSH public key '{{ __ha_cluster_ssh_key }}' from each node
+- name: Slurp SSH public key from each node
   ansible.builtin.slurp:
     src: "{{ __ha_cluster_ssh_path }}/{{ __ha_cluster_ssh_key }}.pub"
   register: __ha_cluster_ssh_pub_key
@@ -143,7 +143,7 @@
     - hostvars[item].__ha_cluster_ssh_pub_key.content is defined
     - hostvars[item].__ha_cluster_ssh_pub_key.content | length > 0
 
-- name: Configure SSH config with '{{ __ha_cluster_ssh_key }}'
+- name: Update SSH config with private SSH key
   ansible.builtin.blockinfile:
     path: "{{ __ha_cluster_ssh_path }}/config"
     create: true

--- a/tasks/shell_crmsh/cluster-setup-corosync.yml
+++ b/tasks/shell_crmsh/cluster-setup-corosync.yml
@@ -13,13 +13,6 @@
   check_mode: false
   changed_when: not ansible_check_mode
 
-# Gather facts for corosync template creation
-- name: Gather facts for corosync template
-  ansible.builtin.setup:
-    filter:
-      - eth0
-      - eth1
-
 - name: Generate corosync.conf using template
   ansible.builtin.template:
     src: crmsh_corosync.j2

--- a/templates/crmsh_corosync.j2
+++ b/templates/crmsh_corosync.j2
@@ -44,7 +44,7 @@ nodelist {
 {% for node in ansible_play_batch %}
         node {
                 nodeid: {{ loop.index }}
-                name: {{ hostvars[node].__ha_cluster_local_node.node_name | d(ansible_hostname) }}
+                name: {{ hostvars[node].__ha_cluster_local_node.node_name | d(hostvars[node]['ansible_hostname']) }}
 {% if hostvars[node].__ha_cluster_local_node.corosync_addresses is defined %}
 {% for addr in hostvars[node].__ha_cluster_local_node.corosync_addresses %}
                 ring{{ loop.index0 }}_addr: {{ addr | quote }}

--- a/templates/crmsh_corosync.j2
+++ b/templates/crmsh_corosync.j2
@@ -2,29 +2,56 @@
 {{ "system_role:ha_cluster" | comment(prefix="", postfix="") }}
 totem {
 {% if ha_cluster_totem and ha_cluster_totem.options | d({}) %}
+{# Add default version if not present in options #}
 {% if ha_cluster_totem.options | selectattr('name', 'equalto', 'version') | list | length == 0 %}
         version: 2
 {% endif %}
+        cluster_name: {{ ha_cluster_cluster_name }}
+{# Use ha_cluster_transport.type if transport is not in options, else use default #}
+{% if ha_cluster_transport is defined and ha_cluster_transport.type is defined and ha_cluster_transport.type | length > 0 and ha_cluster_totem.options | selectattr('name', 'equalto', 'transport') | list | length == 0 %}
+        transport: {{ ha_cluster_transport.type | quote }}
+{% elif ha_cluster_totem.options | selectattr('name', 'equalto', 'transport') | list | length == 0 %}
+        transport: {{ __ha_cluster_transport.type | d('udpu') }}
+{% endif %}
 {% for option in ha_cluster_totem.options %}
+{# Use ha_cluster_transport.type if defined instead of options.transport #}
+{% if ha_cluster_transport is defined and ha_cluster_transport.type is defined and ha_cluster_transport.type | length > 0 and option.name == 'transport' %}
+        transport: {{ option.value | quote }}
+{# Ignore options that are already defined in ha_cluster_transport.options #}
+{% elif ha_cluster_transport is defined
+and ha_cluster_transport.options | d([]) | selectattr('name', 'equalto', option.name) | list | length == 0
+and ha_cluster_transport.crypto | d([]) | selectattr('name', 'equalto', option.name) | list | length == 0
+and ha_cluster_transport.compression | d([]) | selectattr('name', 'equalto', option.name) | list | length == 0 %}
+        {{ option.name | quote }}: {{ option.value | quote }}
+{% endif %}
+{% endfor %}
+{% endif %}
+{% if ha_cluster_transport and ha_cluster_transport.options | d({}) %}
+{% for option in ha_cluster_transport.options %}
         {{ option.name | quote }}: {{ option.value | quote }}
 {% endfor %}
-{% if ha_cluster_totem.options | selectattr('name', 'equalto', 'transport') | list | length == 0 %}
-        transport: udpu        
-{% endif %}
-{% else %}
-        # Default values are configured because ha_cluster_totem.options was not defined
-        version: 2
-        transport: udpu
+{% elif ha_cluster_transport and ha_cluster_transport.crypto | d({}) %}
+{% for crypto in ha_cluster_transport.crypto %}
+        {{ crypto.name | quote }}: {{ crypto.value | quote }}
+{% endfor %}
+{% elif ha_cluster_transport and ha_cluster_transport.compression | d({}) %}
+{% for compression in ha_cluster_transport.compression %}
+        {{ compression.name | quote }}: {{ compression.value | quote }}
+{% endfor %}
 {% endif %}
 }
 nodelist {
-{% for host in ansible_play_batch %}
-       node {
-               nodeid: {{ loop.index }}
-               ring0_addr: {{ hostvars[host]['ansible_facts']['eth0']['ipv4']['address'] }}
-               {% if hostvars[host]['ansible_facts']['eth1']['ipv4']['address'] is defined %}
-               ring1_addr: {{ hostvars[host]['ansible_facts']['eth1']['ipv4']['address'] }}
-               {% endif -%}
+{% for node in ansible_play_batch %}
+        node {
+                nodeid: {{ loop.index }}
+                name: {{ hostvars[node].__ha_cluster_local_node.node_name | d(ansible_hostname) }}
+{% if hostvars[node].__ha_cluster_local_node.corosync_addresses is defined %}
+{% for addr in hostvars[node].__ha_cluster_local_node.corosync_addresses %}
+                ring{{ loop.index0 }}_addr: {{ addr | quote }}
+{% endfor %}
+{% else %}
+                ring0_addr: {{ hostvars[node].__ha_cluster_local_node.pcs_address | d(ansible_default_ipv4.address) }}
+{% endif -%}
        }
 {% endfor %}
 }
@@ -40,7 +67,6 @@ quorum {
         two_node: 1    
 {% endif %}
 {% else %}
-        # Default values are configured because ha_cluster_quorum.options was not defined
         provider: corosync_votequorum
         two_node: 1
 {% endif %}

--- a/vars/SLES_15.yml
+++ b/vars/SLES_15.yml
@@ -4,7 +4,7 @@
 # - SUSE Linux Enterprise Server for SAP Applications 15
 # - SUSE Linux Enterprise Server 15
 
-__ha_cluster_patterns:
+__ha_cluster_zypper_patterns:
   - ha_sles
 
 __ha_cluster_role_essential_packages:

--- a/vars/SLES_16.yml
+++ b/vars/SLES_16.yml
@@ -1,42 +1,27 @@
 ---
 
 # Variables specific to following versions:
-# - SUSE Linux Enterprise Server for SAP Applications 15
-# - SUSE Linux Enterprise Server 15
+# - SUSE Linux Enterprise Server for SAP Applications 16
+# - SUSE Linux Enterprise Server 16
 
 __ha_cluster_patterns:
   - ha_sles
 
 __ha_cluster_role_essential_packages:
-  - 'cluster-glue'
   - 'openssl'
-#  - 'libxml2-tools'
 
 # Pattern ha_sles includes all important packages for cluster
 # Requires: SUSE Linux Enterprise High Availability Extension on SLES
-# - 'conntrack-tools'
 # - 'corosync'
 # - 'crmsh'
 # - 'csync2'
-# - 'ctdb'
-# - 'drbd'
-# - 'drbd-utils'
-# - 'fence-agents'
-# - 'ha-cluster-bootstrap'
-# - 'ha-cluster-webui'
-# - 'ldirectord'
-# - 'lvm2-lockd'
-# - 'ocfs2-tools'
 # - 'pacemaker'
-# - 'python3-dateutil'
-# - 'release-notes-ha'
 # - 'resource-agents'
 # - 'sbd'
-# - 'yast2-cluster'
-# - 'yast2-drbd'
-# - 'yast2-iplb'
 # - 'chrony'
+# - 'fence-agents-sbd'
+# - 'lvm2-lockd'
 
 # Default totem transport configuration
 __ha_cluster_transport:
-  type: udpu
+  type: knet

--- a/vars/SLES_16.yml
+++ b/vars/SLES_16.yml
@@ -4,7 +4,7 @@
 # - SUSE Linux Enterprise Server for SAP Applications 16
 # - SUSE Linux Enterprise Server 16
 
-__ha_cluster_patterns:
+__ha_cluster_zypper_patterns:
   - ha_sles
 
 __ha_cluster_role_essential_packages:

--- a/vars/Suse.yml
+++ b/vars/Suse.yml
@@ -5,8 +5,10 @@ ha_cluster_pacemaker_shell: crmsh
 # Placeholder with pcs name
 __ha_cluster_pcs_provider: crm
 
+# ha_sles pattern requires SLES or SLES4SAP
+__ha_cluster_patterns: []
+
 # ClusterTools2 removed because it is SLES4SAP specific
-# patterns-ha-ha_sles requires SLES 15 SP5+ or SLES4SAP 15
 __ha_cluster_role_essential_packages:
   - 'pacemaker'
   - 'corosync'

--- a/vars/Suse.yml
+++ b/vars/Suse.yml
@@ -6,7 +6,7 @@ ha_cluster_pacemaker_shell: crmsh
 __ha_cluster_pcs_provider: crm
 
 # ha_sles pattern requires SLES or SLES4SAP
-__ha_cluster_patterns: []
+__ha_cluster_zypper_patterns: []
 
 # ClusterTools2 removed because it is SLES4SAP specific
 __ha_cluster_role_essential_packages:


### PR DESCRIPTION
Enhancement:
- Added SLES 16 variables and adjustments regarding `HAE` detection.
- Added new variable `ha_cluster_patterns` for zypper patterns
- Added some recent `pcs` improvements to variable handling to `crmsh` files
- Updated `corosync` jinja2 template to remove dependencies on NIC names and improve generation (Formatting is still not great, but any change to actual formatting results in unreadable corosync file).
- Added authentication workflow for SSH keys, that are required for cross cluster commands like `crm report` or `crm cluster start --all`.
- Added authentication workflow to onboard non-root user for cluster administration.

Reason:
- SLES 16 Beta 4 is public and we are testing and adjusting everything
- Installing patterns using previous method results in inconsistent package count, where using zypper patterns directly produces more consistent results

Result:
- Testing was completed on `SLES_SAP 15 SP6` and `SLES_SAP 16 Beta 4`

Issue Tracker Tickets (Jira or BZ if any):
