### PR TITLE
refactor: support Ansible 2.19

### DIFF
--- a/tasks/shell_pcs/check-and-prepare-role-variables.yml
+++ b/tasks/shell_pcs/check-and-prepare-role-variables.yml
@@ -39,7 +39,7 @@
           (
             __nodes_from_options != (__nodes_from_options | unique)
           ) or (
-            __nodes_from_options | difference(__ha_cluster_all_node_names)
+            __nodes_from_options | difference(__ha_cluster_all_node_names) | list | length > 0
           )
 
 - name: Extract node options
@@ -166,7 +166,7 @@
   when:
     - ha_cluster_pcsd_public_key_src is not none
     - ha_cluster_pcsd_private_key_src is not none
-    - ha_cluster_pcsd_certificates | d([])
+    - ha_cluster_pcsd_certificates | d([]) | length > 0
 
 - name: Fetch pcs capabilities
   command:
@@ -216,11 +216,11 @@
       defaults. Please, upgrade pcs.
   when:
     - (
-        ha_cluster_resource_defaults
+        ha_cluster_resource_defaults | length > 0
         and not 'pcmk.properties.resource-defaults.multiple'
         in __ha_cluster_pcs_capabilities
       ) or (
-        ha_cluster_resource_operation_defaults
+        ha_cluster_resource_operation_defaults | length > 0
         and not 'pcmk.properties.operation-defaults.multiple'
         in __ha_cluster_pcs_capabilities
       )

--- a/tasks/shell_pcs/configure-shell.yml
+++ b/tasks/shell_pcs/configure-shell.yml
@@ -53,11 +53,8 @@
       include_role:
         name: fedora.linux_system_roles.certificate
       vars:
-        certificate_requests: |
-          {% for _cert in ha_cluster_pcsd_certificates %}
-          {%   set _ = _cert.__setitem__('name', '/var/lib/pcsd/pcsd') %}
-          {% endfor %}
-          {{ ha_cluster_pcsd_certificates }}
+        certificate_requests: "{{ ha_cluster_pcsd_certificates |
+          map('combine', {'name': '/var/lib/pcsd/pcsd'}) | list }}"
   always:
     - name: Set pcsd's certificate directory back to cluster_var_lib_t
       file:

--- a/tasks/shell_pcs/create-and-push-cib.yml
+++ b/tasks/shell_pcs/create-and-push-cib.yml
@@ -93,7 +93,9 @@
       # ha_cluster_cluster_properties
       vars:
         properties_set: "{{ ha_cluster_cluster_properties[0] }}"
-      when: ha_cluster_cluster_properties[0].attrs | d([])
+      when:
+        - ha_cluster_cluster_properties[0].attrs | d(none) is not none
+        - ha_cluster_cluster_properties[0].attrs | length > 0
 
     ## Node attributes
     - name: Configure node attributes
@@ -190,7 +192,7 @@
 
     - name: Configure resource colocation constraints
       include_tasks: pcs-cib-constraint-colocation.yml
-      when: not constraint.resource_sets | d()
+      when: constraint.resource_sets | d([]) | length == 0
       loop: "{{ ha_cluster_constraints_colocation }}"
       loop_control:
         index_var: constraint_index
@@ -200,7 +202,7 @@
       include_tasks: pcs-cib-constraint-set.yml
       vars:
         constraint_type: colocation
-      when: constraint.resource_sets | d()
+      when: constraint.resource_sets | d([]) | length > 0
       loop: "{{ ha_cluster_constraints_colocation }}"
       loop_control:
         index_var: constraint_index
@@ -208,7 +210,7 @@
 
     - name: Configure resource order constraints
       include_tasks: pcs-cib-constraint-order.yml
-      when: not constraint.resource_sets | d()
+      when: constraint.resource_sets | d([]) | length == 0
       loop: "{{ ha_cluster_constraints_order }}"
       loop_control:
         index_var: constraint_index
@@ -218,7 +220,7 @@
       include_tasks: pcs-cib-constraint-set.yml
       vars:
         constraint_type: order
-      when: constraint.resource_sets | d()
+      when: constraint.resource_sets | d([]) | length > 0
       loop: "{{ ha_cluster_constraints_order }}"
       loop_control:
         index_var: constraint_index
@@ -226,7 +228,7 @@
 
     - name: Configure resource ticket constraints
       include_tasks: pcs-cib-constraint-ticket.yml
-      when: not constraint.resource_sets | d()
+      when: constraint.resource_sets | d([]) | length == 0
       loop: "{{ ha_cluster_constraints_ticket }}"
       loop_control:
         index_var: constraint_index
@@ -236,7 +238,7 @@
       include_tasks: pcs-cib-constraint-set.yml
       vars:
         constraint_type: ticket
-      when: constraint.resource_sets | d()
+      when: constraint.resource_sets | d([]) | length > 0
       loop: "{{ ha_cluster_constraints_ticket }}"
       loop_control:
         index_var: constraint_index

--- a/tasks/shell_pcs/pcs-cib-resource-group.yml
+++ b/tasks/shell_pcs/pcs-cib-resource-group.yml
@@ -23,7 +23,9 @@
       {% for attr in resource_group.meta_attrs[0].attrs %}
         {{ attr.name | quote }}={{ attr.value | quote }}
       {% endfor %}
-  when: resource_group.meta_attrs[0].attrs | d([])
+  when:
+    - resource_group.meta_attrs[0].attrs | d(none) is not none
+    - resource_group.meta_attrs[0].attrs | length > 0
   # We always need to create CIB to see whether it's the same as what is
   # already present in the cluster. However, we don't want to report it as a
   # change since the only thing which matters is pushing the resulting CIB to

--- a/tasks/shell_pcs/pcs-cib-resource-primitive.yml
+++ b/tasks/shell_pcs/pcs-cib-resource-primitive.yml
@@ -75,4 +75,4 @@
   check_mode: false
   changed_when: not ansible_check_mode
   when:
-    - resource.utilization | d([])
+    - resource.utilization | d([]) | length > 0

--- a/tests/tasks/check_header.yml
+++ b/tests/tasks/check_header.yml
@@ -9,8 +9,8 @@
 - name: Check for presence of ansible managed header, fingerprint
   assert:
     that:
-      - ansible_managed in content
+      - __ansible_managed in content
       - __fingerprint in content
   vars:
     content: "{{ (__file_content | d(__content)).content | b64decode }}"
-    ansible_managed: "{{ lookup('template', 'get_ansible_managed.j2') }}"
+    __ansible_managed: "{{ lookup('template', 'get_ansible_managed.j2') }}"

--- a/tests/tests_cib_constraints_create.yml
+++ b/tests/tests_cib_constraints_create.yml
@@ -546,11 +546,11 @@
 
             - name: Print real location constraints configuration
               debug:
-                var: __test_pcs_location_config.stdout_lines
+                msg: __test_pcs_location_config {{ __test_pcs_location_config.stdout_lines | sort | list | to_nice_json }}
 
             - name: Print expected location constraints configuration
               debug:
-                var: __test_expected_lines | select | list
+                msg: __test_expected_lines {{ __test_expected_lines | select | sort | list | to_nice_json }}
 
             - name: Check location constraints configuration
               assert:
@@ -849,9 +849,9 @@
                                                 "id": "cl7-rule-rule",
                                                 "in_effect": "UNKNOWN",
                                                 "options": {
-                                                    "boolean-op": "or",
+                                                    "boolean-op": "or"
                                                     {% if __test_inner_rules_score %}
-                                                      "score": "0"
+                                                      ,"score": "0"
                                                     {% endif %}
                                                 },
                                                 "type": "RULE"
@@ -937,9 +937,9 @@
                                                 "id": "cl8-rule-rule",
                                                 "in_effect": "UNKNOWN",
                                                 "options": {
-                                                    "boolean-op": "or",
+                                                    "boolean-op": "or"
                                                     {% if __test_inner_rules_score %}
-                                                      "score": "0"
+                                                      ,"score": "0"
                                                     {% endif %}
                                                 },
                                                 "type": "RULE"
@@ -1236,9 +1236,9 @@
                                                 "id": "location-d3-3-rule-rule",
                                                 "in_effect": "UNKNOWN",
                                                 "options": {
-                                                    "boolean-op": "or",
+                                                    "boolean-op": "or"
                                                     {% if __test_inner_rules_score %}
-                                                      "score": "0"
+                                                      ,"score": "0"
                                                     {% endif %}
                                                 },
                                                 "type": "RULE"
@@ -1323,9 +1323,9 @@
                                                 "id": "location-dd-3-rule-rule",
                                                 "in_effect": "UNKNOWN",
                                                 "options": {
-                                                    "boolean-op": "or",
+                                                    "boolean-op": "or"
                                                     {% if __test_inner_rules_score %}
-                                                      "score": "0"
+                                                      ,"score": "0"
                                                     {% endif %}
                                                 },
                                                 "type": "RULE"
@@ -1545,6 +1545,8 @@
                     "ticket": [],
                     "ticket_set": []
                 }
+            __expected: "{{ __test_expected_lines if __test_expected_lines | type_debug == 'dict'
+              else __test_expected_lines | from_json }}"
           block:
             - name: Fetch location constraints configuration from the cluster
               command:
@@ -1554,16 +1556,16 @@
 
             - name: Print real location constraints configuration
               debug:
-                var: __test_pcs_location_config.stdout | from_json
+                msg: actual {{ __test_pcs_location_config.stdout | from_json | to_nice_json }}
 
             - name: Print expected location constraints configuration
               debug:
-                var: __test_expected_lines
+                msg: expected {{ __expected | to_nice_json }}
 
             - name: Check location constraints configuration
               assert:
                 that:
-                  - __test_pcs_location_config.stdout | from_json == __test_expected_lines
+                  - __test_pcs_location_config.stdout | from_json == __expected
 
         - name: Verify colocation constraints
           when:
@@ -2209,7 +2211,7 @@
 
             - name: Print expected ticket constraints configuration
               debug:
-                var: __test_expected_lines | from_json
+                var: __test_expected_lines | from_json | to_nice_json
 
             - name: Check ticket constraints configuration
               assert:


### PR DESCRIPTION
Ansible 2.19 introduces some big changes
https://docs.ansible.com/ansible/devel/porting_guides/porting_guide_core_2.19.html

One big change is that data structures are no longer mutable by the use of python
methods such as `__setitem__`, `setdefault`, `update`, etc.  in Jinja constructs.
Instead, items must use filters or other Jinja operations.

One common idiom is to mutate each element in a list.  Since we cannot do this
"in-place" anymore, a common way to do this is:

```yaml
- name: Construct a new list from an existing list and mutate each element
  set_fact:
    __new_list: "{{ __new_list | d([]) + [mutated_item] }}"
  loop: "{{ old_list }}"
  mutated_item: "{{ some value based on item from old list }}"

- name: Reset original old list
  set_fact:
    old_list: "{{ __new_list }}"
```

Similarly with `dict` items:

```yaml
- name: Construct a new dict from an existing dict and mutate each element
  set_fact:
    __new_dict: "{{ __new_dict | d({}) | combine(mutated_item) }}"
  loop: "{{ old_dict | dict2items }}"
  mutated_item: "{{ {item.key: mutation of item.value} }}"

- name: Reset original old dict
  set_fact:
    old_dict: "{{ __new_dict }}"
```

Another big change is that a boolean expression in a `when` or similar construct
must be converted to a boolean - we cannot rely on the implicit evaluation in
a boolean context.  For example, if `var` is some iterable, like a `dict`, `list`,
or `string`, you used to be able to evaluate an empty value in a boolean context:

```yaml
when: var  # do this only if var is not empty
```

You now have to explicitly test for empty using `length`:

```yaml
when: var | length > 0  # do this only if var is not empty
```

For tests_cib_constraints_create.yml - for some reason the formatting
was off, and doing the comparison of the expected data structure with
the actual one was not working.  Instead, convert both to internal
data structures with `from_json` and compare the data structures.

These are the biggest changes.  See the porting guide for others.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Refactor role tasks and tests for compatibility with Ansible 2.19’s strict immutability and boolean evaluation rules by converting implicit mutations and condition checks into filter-based operations and updating tests to normalize and compare JSON structures.

Bug Fixes:
- Fix formatting in location constraints tests to properly compare expected vs actual JSON via `from_json`.
- Correct header test to use the renamed `__ansible_managed` lookup variable for assertion.

Enhancements:
- Refactor all when conditions to enforce explicit boolean evaluation using length checks and `is not none` filters.
- Migrate Jinja2 data mutations to filter-based constructs (combine, map, default) in place of in-place methods for list and dict transformations.
- Simplify certificate_requests generation by mapping each dict with `combine` instead of using `__setitem__` in loops.
- Standardize JSON output in debug tasks using `to_nice_json` and sorted lists for consistent readability.

Tests:
- Convert both actual and expected outputs to parsed JSON structures with `from_json` before assertion in constraint tests.