### PR TITLE
ci: use py311 for pylint

### DIFF
--- a/.github/workflows/python-unit-test.yml
+++ b/.github/workflows/python-unit-test.yml
@@ -120,7 +120,7 @@ jobs:
           # NOTE: The use of flake8, pylint, black with specific
           # python envs is arbitrary and must be changed in tox-lsr
           case "$toxpyver" in
-          310) toxenvs="${toxenvs},coveralls,flake8,pylint,black" ;;
+          311) toxenvs="${toxenvs},coveralls,flake8,pylint,black" ;;
           *) toxenvs="${toxenvs},coveralls" ;;
           esac
           TOXENV="$toxenvs" lsr_ci_runtox


### PR DESCRIPTION
Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

CI:
- Switch CI workflow to use Python 3.11 for pylint, flake8, black, and coverage checks