### PR TITLE
ci: update pcs test matrix

### DIFF
--- a/.github/workflows/python-unit-test.yml
+++ b/.github/workflows/python-unit-test.yml
@@ -52,10 +52,18 @@ jobs:
             pcs_version: v0.11.9
             pcs_dir_local: ''
             pcs_site_packages: site-packages
+          - os: ubuntu-22.04
+            pcs_version: v0.11.10
+            pcs_dir_local: ''
+            pcs_site_packages: site-packages
           - os: ubuntu-24.04
             # v0.12.0 contains a bug preventing it being build in CI
             # v0.12.0-lsr-ci fixes that bug while not adding any other changes
             pcs_version: v0.12.0-lsr-ci
+            pcs_dir_local: '/local'
+            pcs_site_packages: dist-packages
+          - os: ubuntu-24.04
+            pcs_version: v0.12.1
             pcs_dir_local: '/local'
             pcs_site_packages: dist-packages
           - os: ubuntu-24.04


### PR DESCRIPTION
## Summary by Sourcery

Update Python unit test CI matrix to include new PCS versions

CI:
- Add PCS v0.11.10 testing on ubuntu-22.04
- Add PCS v0.12.1 testing on ubuntu-24.04