### PR TITLE
test: don't use fence_xvm in tests

### DIFF
--- a/tests/tests_cib_resources_create_and_load_info.yml
+++ b/tests/tests_cib_resources_create_and_load_info.yml
@@ -246,7 +246,7 @@
               - name: role
                 value: "{{ __unpromoted }}"
       - id: F1
-        agent: "stonith:fence_xvm"
+        agent: "stonith:fence_kdump"
         copy_operations_from_agent: false
         instance_attrs:
           - attrs:


### PR DESCRIPTION
Enhancement:
Don't use fence_xvm in tests.

Reason:
The fence_xvm agent / fence-virt package is only available for x86_64 architecture. Using fence_xvm in tests caused they failed on e.g. aarch64.

Result:
Removed reason of tests fail on aarch64.

Issue Tracker Tickets (Jira or BZ if any):

## Summary by Sourcery

Replace the x86_64-only fence_xvm agent in test configurations with fence_kdump to ensure compatibility across architectures.

Bug Fixes:
- Fix test failures on non-x86_64 architectures by removing dependency on fence_xvm

Tests:
- Update tests/tests_cib_resources_create_and_load_info.yml to use stonith:fence_kdump instead of stonith:fence_xvm