### PR TITLE
fix: crsmh corosync template wrongly used variable from run_once host

### DIFF
--- a/templates/crmsh_corosync.j2
+++ b/templates/crmsh_corosync.j2
@@ -50,7 +50,7 @@ nodelist {
                 ring{{ loop.index0 }}_addr: {{ addr | quote }}
 {% endfor %}
 {% else %}
-                ring0_addr: {{ hostvars[node].__ha_cluster_local_node.pcs_address | d(ansible_default_ipv4.address) }}
+                ring0_addr: {{ hostvars[node].__ha_cluster_local_node.pcs_address | d(hostvars[node]['ansible_default_ipv4']['address']) }}
 {% endif -%}
        }
 {% endfor %}


### PR DESCRIPTION
Enhancement:
Fixes potential issue with defaulting to wrong IP variable when `ha_cluster` or `ha_cluster_node_options` are not provided

Reason:
Running cluster setup without specifying IP inside of `ha_cluster` or `ha_cluster_node_options` would result in corosync nodes with same IP assigned because of `run_once`.

Result:
Tested on SLES 16 without providing `ha_cluster` variable to use `d()`.
```bash
cat /etc/corosync/corosync.conf                                                                             h02hana1: 12:39:01                                                                                                                             in 0.008s (0)#
# Ansible managed
#
# system_role:ha_cluster

totem {
        version: 2
        cluster_name: clusterhdb
        transport: knet
        token: 5000
        token_retransmits_before_loss_const: 10
        join: 60
        consensus: 6000
        max_messages: 20
        crypto_hash: sha256
        crypto_cipher: aes256
}
nodelist {
        node {
                nodeid: 1
                name: h02hana0
                ring0_addr: 10.144.74.244
}
        node {
                nodeid: 2
                name: h02hana1
                ring0_addr: 10.144.74.245
}
}
quorum {
        provider: corosync_votequorum
```

## Summary by Sourcery

Bug Fixes:
- Use proper dictionary syntax to access ansible_default_ipv4.address in the Jinja2 template instead of the incorrect attribute notation