### PR TITLE
refactor: crmsh update for ansible-core 2.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -746,7 +746,7 @@ ha_cluster_resource_groups:
 This variable defines resource groups. The items are as follows:
 
 * `id` (mandatory) - ID of a group.
-* `resources` (mandatory) - List of the group's resources. Each resource is
+* `resource_ids` (mandatory) - List of the group's resources. Each resource is
   referenced by its ID and the resources must be defined in
   [`ha_cluster_resource_primitives`](#ha_cluster_resource_primitives). At least
   one resource must be listed.

--- a/tasks/shell_crmsh/check-and-prepare-role-variables.yml
+++ b/tasks/shell_crmsh/check-and-prepare-role-variables.yml
@@ -29,7 +29,7 @@
           (
             __nodes_from_options != (__nodes_from_options | unique)
           ) or (
-            __nodes_from_options | difference(__ha_cluster_all_node_names)
+            __nodes_from_options | difference(__ha_cluster_all_node_names) | list | length > 0
           )
 
 - name: Extract node options

--- a/tasks/shell_crmsh/create-and-push-cib.yml
+++ b/tasks/shell_crmsh/create-and-push-cib.yml
@@ -163,7 +163,7 @@
     ## Stonith levels - fencing_topology
     - name: Configure stonith levels - fencing_topology
       ansible.builtin.include_tasks: crm-cib-stonith-level.yml
-      when: ha_cluster_stonith_levels
+      when: ha_cluster_stonith_levels | length > 0
 
     ## Constraints
     - name: Configure resource location constraints
@@ -175,7 +175,7 @@
 
     - name: Configure resource colocation constraints
       ansible.builtin.include_tasks: crm-cib-constraint-colocation.yml
-      when: not constraint.resource_sets | d()
+      when: constraint.resource_sets | d([]) | length == 0
       loop: "{{ ha_cluster_constraints_colocation }}"
       loop_control:
         index_var: constraint_index
@@ -185,7 +185,7 @@
       ansible.builtin.include_tasks: crm-cib-constraint-set.yml
       vars:
         constraint_type: colocation
-      when: constraint.resource_sets | d()
+      when: constraint.resource_sets | d([]) | length > 0
       loop: "{{ ha_cluster_constraints_colocation }}"
       loop_control:
         index_var: constraint_index
@@ -193,7 +193,7 @@
 
     - name: Configure resource order constraints
       ansible.builtin.include_tasks: crm-cib-constraint-order.yml
-      when: not constraint.resource_sets | d()
+      when: constraint.resource_sets | d([]) | length == 0
       loop: "{{ ha_cluster_constraints_order }}"
       loop_control:
         index_var: constraint_index
@@ -203,7 +203,7 @@
       ansible.builtin.include_tasks: crm-cib-constraint-set.yml
       vars:
         constraint_type: order
-      when: constraint.resource_sets | d()
+      when: constraint.resource_sets | d([]) | length > 0
       loop: "{{ ha_cluster_constraints_order }}"
       loop_control:
         index_var: constraint_index
@@ -211,7 +211,7 @@
 
     - name: Configure resource ticket constraints
       ansible.builtin.include_tasks: crm-cib-constraint-ticket.yml
-      when: not constraint.resource_sets | d()
+      when: constraint.resource_sets | d([]) | length == 0
       loop: "{{ ha_cluster_constraints_ticket }}"
       loop_control:
         index_var: constraint_index
@@ -221,7 +221,7 @@
       ansible.builtin.include_tasks: crm-cib-constraint-set.yml
       vars:
         constraint_type: ticket
-      when: constraint.resource_sets | d()
+      when: constraint.resource_sets | d([]) | length > 0
       loop: "{{ ha_cluster_constraints_ticket }}"
       loop_control:
         index_var: constraint_index
@@ -232,7 +232,9 @@
       ansible.builtin.include_tasks: crm-cluster-properties.yml
       vars:
         properties_set: "{{ ha_cluster_cluster_properties[0] }}"
-      when: ha_cluster_cluster_properties[0].attrs | d([])
+      when:
+        - ha_cluster_cluster_properties[0].attrs | d(none) is not none
+        - ha_cluster_cluster_properties[0].attrs | length > 0
 
     # Verify CIB to ensure that there are no errors before applying.
     - name: Verify shadow CIB

--- a/tasks/shell_crmsh/crm-cib-constraint-colocation.yml
+++ b/tasks/shell_crmsh/crm-cib-constraint-colocation.yml
@@ -62,14 +62,14 @@
       {% else %}
         inf: \
       {% endfor %}
-      {% if constraint.resource_follower.role | d() and
+      {% if constraint.resource_follower.role is defined and
       constraint.resource_follower.role | lower in __ha_cluster_crmsh_roles %}
         {{ constraint.resource_follower.id | quote }}:{{
           constraint.resource_follower.role | lower | capitalize | quote }} \
       {% else %}
         {{ constraint.resource_follower.id | quote }} \
       {% endif %}
-      {% if constraint.resource_leader.role | d() and
+      {% if constraint.resource_leader.role is defined and
         constraint.resource_leader.role | lower in __ha_cluster_crmsh_roles %}
         {{ constraint.resource_leader.id | quote }}:{{
           constraint.resource_leader.role | lower | capitalize | quote }} \

--- a/tasks/shell_crmsh/crm-cib-constraint-location.yml
+++ b/tasks/shell_crmsh/crm-cib-constraint-location.yml
@@ -50,18 +50,18 @@
     cmd: >-
       yes 'n' | crm -c {{ __ha_cluster_crm_shadow }}
       configure location {{ __ha_cluster_constraint_id }}
-      {%- if constraint.resource.pattern | d() %}
+      {%- if constraint.resource.pattern is defined %}
         /{{ constraint.resource.pattern | quote }}/
       {%- else %}
         {{ constraint.resource.id | quote }}
       {%- endif %}
-      {%- if constraint.resource.role | d() and
+      {%- if constraint.resource.role is defined and
         constraint.resource.role | lower in __ha_cluster_crmsh_roles %}
           role={{
             constraint.resource.role | lower | capitalize | quote
           }}
         {%- endif %}
-      {%- if constraint.rule | d() %}
+      {%- if constraint.rule is defined %}
         rule {{ __score }}{{ constraint.rule }}
       {%- else %}
         {{ __score }} {{ constraint.node }}

--- a/tasks/shell_crmsh/crm-cib-constraint-set.yml
+++ b/tasks/shell_crmsh/crm-cib-constraint-set.yml
@@ -91,7 +91,7 @@
         {%- endif %}
         {{ __ha_cluster_resource_ids_string }}
       {%- else %}
-        {%- for set in constraint.resource_sets %}
+        {%- for set in constraint.resource_sets | d([]) %}
           {{ constraint.ticket | quote }}: {{ __ha_cluster_resource_ids_string }}
         {%- endfor %}
       {%- endif %}

--- a/tasks/shell_crmsh/crm-cib-constraint-ticket.yml
+++ b/tasks/shell_crmsh/crm-cib-constraint-ticket.yml
@@ -45,8 +45,8 @@
   ansible.builtin.shell:
     cmd: |
       yes 'n' | crm -c {{ __ha_cluster_crm_shadow }} configure rsc_ticket \
-      {{ __ha_cluster_constraint_id }} {{ constraint.ticket | quote }}: \
-      {% if constraint.resource.role | d() and
+        {{ __ha_cluster_constraint_id }} {{ constraint.ticket | quote }}: \
+      {% if constraint.resource.role is defined and
         constraint.resource.role | lower in __ha_cluster_crmsh_roles %}
         {{ constraint.resource.id | quote }}:{{
           constraint.resource.role | lower | capitalize | quote }} \

--- a/tasks/shell_crmsh/crm-cib-resource-clone.yml
+++ b/tasks/shell_crmsh/crm-cib-resource-clone.yml
@@ -53,7 +53,10 @@
         ms {% else %} clone {% endif %} \
       {{ __ha_cluster_resource_id }} \
       {{ resource_clone.resource_id | quote }} \
-      {% if resource_clone.meta_attrs[0].attrs | default(False) %}
+      {% if resource_clone.meta_attrs is defined
+        and resource_clone.meta_attrs | type_debug == 'list'
+        and resource_clone.meta_attrs[0].attrs is defined
+        and resource_clone.meta_attrs[0].attrs | type_debug == 'list' %}
         meta {% for attr in resource_clone.meta_attrs[0].attrs -%}
           {{ attr.name | quote }}={{ attr.value | quote }} \
         {% endfor %}

--- a/tasks/shell_crmsh/crm-cib-resource-group.yml
+++ b/tasks/shell_crmsh/crm-cib-resource-group.yml
@@ -40,11 +40,14 @@
   ansible.builtin.shell:
     cmd: |
       yes 'n' | crm -c {{ __ha_cluster_crm_shadow }} configure group \
-      {{ resource_group.id | quote }} \
+        {{ resource_group.id | quote }} \
       {% for resource in resource_group.resource_ids %}
         {{ resource | quote }} \
       {% endfor %}
-      {% if resource_group.meta_attrs[0].attrs | default(False) %}
+      {% if resource_group.meta_attrs is defined
+        and resource_group.meta_attrs | type_debug == 'list'
+        and resource_group.meta_attrs[0].attrs is defined
+        and resource_group.meta_attrs[0].attrs | type_debug == 'list' %}
         meta {% for attr in resource_group.meta_attrs[0].attrs -%}
           {{ attr.name | quote }}={{ attr.value | quote }} \
         {% endfor %}

--- a/tasks/shell_crmsh/crm-cib-resource-primitive.yml
+++ b/tasks/shell_crmsh/crm-cib-resource-primitive.yml
@@ -26,25 +26,32 @@
     cmd: |
       yes 'n' | crm -c {{ __ha_cluster_crm_shadow }} configure primitive \
         {{ resource.id | quote }} {{ resource.agent | quote }} \
-      {% if resource.instance_attrs[0].attrs | default(False) %}
+      {% if resource.instance_attrs is defined
+        and resource.instance_attrs | type_debug == 'list'
+        and resource.instance_attrs[0].attrs is defined
+        and resource.instance_attrs[0].attrs | type_debug == 'list' %}
         params {% for attr in resource.instance_attrs[0].attrs -%}
           {{ attr.name | quote }}={{ attr.value | quote }} \
         {% endfor %}
       {% endif %}
-      {% if resource.meta_attrs[0].attrs | default(False) %}
+      {% if resource.meta_attrs is defined
+        and resource.meta_attrs | type_debug == 'list'
+        and resource.meta_attrs[0].attrs is defined
+        and resource.meta_attrs[0].attrs | type_debug == 'list' %}
         meta {% for attr in resource.meta_attrs[0].attrs -%}
           {{ attr.name | quote }}={{ attr.value | quote }} \
         {% endfor %}
       {% endif %}
-      {% if resource.operations | default(False) %}\
+      {% if resource.operations is defined
+        and resource.operations | type_debug == 'list' %}\
         {% for operation in resource.operations %}
-          {% if operation.action | default(False) %}
+          {% if operation.action is defined
+            and operation.attrs is defined
+            and operation.attrs | type_debug == 'list' %}
             op {{ operation.action | quote }} \
-            {% if operation.attrs | default(False) %}
-              {%- for attr in operation.attrs -%}
-                {{ attr.name | quote }}={{ attr.value | quote }} \
-              {% endfor %}
-            {% endif %}
+            {%- for attr in operation.attrs -%}
+              {{ attr.name | quote }}={{ attr.value | quote }} \
+            {% endfor %}
           {% endif %}
         {% endfor %}
       {% endif %}

--- a/tasks/shell_crmsh/crm-cib-stonith-level.yml
+++ b/tasks/shell_crmsh/crm-cib-stonith-level.yml
@@ -28,9 +28,9 @@
       yes 'n' | crm -c {{ __ha_cluster_crm_shadow }} \
       configure fencing_topology \
       {% for stonith_level in ha_cluster_stonith_levels -%}
-        {% if stonith_level.target | d() %}
+        {% if stonith_level.target is defined %}
           {{ stonith_level.target | quote }}: \
-        {% elif stonith_level.target_pattern | d() %}
+        {% elif stonith_level.target_pattern is defined %}
           regexp%{{ stonith_level.target_pattern | quote }}: \
         {% endif %}
         {% for resource_id in stonith_level.resource_ids %}


### PR DESCRIPTION
Enhancement:
- Replicate `pcs` code changes into `crmsh` for `ansible-core 2.19` and update other code that is not shared.

Reason:
- https://github.com/linux-system-roles/ha_cluster/pull/286 Did not include `crmsh` part of code.

Result:
Tested on SLES 16 for SAP HANA HA and SAP ASCS/ERS clusters using `ansible-core 2.18` and `ansible-core 2.19`.

Issue Tracker Tickets (Jira or BZ if any):

## Summary by Sourcery

Update crmsh tasks to align with recent pcs changes and adjust conditional logic for compatibility with ansible-core 2.19, and update related documentation.

Enhancements:
- Add explicit defined and type_debug checks before iterating over attrs, meta_attrs, and operations in crmsh resource and clone tasks
- Replace default and d() fallbacks in when clauses with explicit length checks for stonith levels, constraints, and cluster properties
- Sync crmsh task logic with corresponding pcs updates

Documentation:
- Rename `resources` to `resource_ids` in the crmsh section of the README for consistency