### PR TITLE
style: fix typos

### DIFF
--- a/tests/tests_sbd_all_options_combined.yml
+++ b/tests/tests_sbd_all_options_combined.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 ---
-# Test SBD configuration defined both in a play and in an inventroy. Those
+# Test SBD configuration defined both in a play and in an inventory. Those
 # variables are merged, with variables defined in a play override variables
 # from an inventory.
 - name: Maximal SBD configuration (inventory + play)

--- a/tests/unit/ha_cluster_info.py
+++ b/tests/unit/ha_cluster_info.py
@@ -40,8 +40,8 @@ def mocked_module(
         ]
     ] = None,
 ) -> Generator:
-    calls, side_efect = zip(*runner_calls) if runner_calls else ([], [])
-    module_mock = mock.Mock(run_command=mock.Mock(side_effect=side_efect))
+    calls, side_effect = zip(*runner_calls) if runner_calls else ([], [])
+    module_mock = mock.Mock(run_command=mock.Mock(side_effect=side_effect))
 
     yield module_mock
 

--- a/tests/unit/test_ha_cluster_info_pcsd.py
+++ b/tests/unit/test_ha_cluster_info_pcsd.py
@@ -17,9 +17,9 @@ class ExportPcsdConfiguration(TestCase):
 
     @mock.patch("ha_cluster_info.loader.get_pcsd_settings_conf")
     def test_permissions_defined(
-        self, mock_load_pcsd_permisions: mock.Mock
+        self, mock_load_pcsd_permissions: mock.Mock
     ) -> None:
-        mock_load_pcsd_permisions.return_value = {
+        mock_load_pcsd_permissions.return_value = {
             "permissions": {
                 "local_cluster": [
                     {
@@ -56,9 +56,9 @@ class ExportPcsdConfiguration(TestCase):
 
     @mock.patch("ha_cluster_info.loader.get_pcsd_settings_conf")
     def test_empty_permissions_defined(
-        self, mock_load_pcsd_permisions: mock.Mock
+        self, mock_load_pcsd_permissions: mock.Mock
     ) -> None:
-        mock_load_pcsd_permisions.return_value = {
+        mock_load_pcsd_permissions.return_value = {
             "permissions": {
                 "local_cluster": [],
             }
@@ -73,9 +73,9 @@ class ExportPcsdConfiguration(TestCase):
 
     @mock.patch("ha_cluster_info.loader.get_pcsd_settings_conf")
     def test_permission_load_error(
-        self, mock_load_pcsd_permisions: mock.Mock
+        self, mock_load_pcsd_permissions: mock.Mock
     ) -> None:
-        mock_load_pcsd_permisions.return_value = None
+        mock_load_pcsd_permissions.return_value = None
 
         self.assertEqual(
             ha_cluster_info.export_pcsd_configuration(),
@@ -84,9 +84,9 @@ class ExportPcsdConfiguration(TestCase):
 
     @mock.patch("ha_cluster_info.loader.get_pcsd_settings_conf")
     def test_permission_load_bad_format(
-        self, mock_load_pcsd_permisions: mock.Mock
+        self, mock_load_pcsd_permissions: mock.Mock
     ) -> None:
-        mock_load_pcsd_permisions.return_value = {
+        mock_load_pcsd_permissions.return_value = {
             "permissions": {
                 "local": [
                     {
@@ -104,7 +104,7 @@ class ExportPcsdConfiguration(TestCase):
             cm.exception.kwargs,
             dict(
                 data_desc="pcs_settings.conf",
-                data=mock_load_pcsd_permisions.return_value,
+                data=mock_load_pcsd_permissions.return_value,
                 issue_location="/permissions",
                 issue_desc="Missing key 'local_cluster'",
             ),

--- a/tests/unit/test_ha_cluster_info_resources.py
+++ b/tests/unit/test_ha_cluster_info_resources.py
@@ -47,7 +47,7 @@ class ExportResourcesConfiguration(TestCase):
                 json.loads(read_file("resources-export.json")),
             )
 
-    def test_no_capabilites(self) -> None:
+    def test_no_capabilities(self) -> None:
         with mocked_module([]) as module_mock:
             self.assertEqual(
                 ha_cluster_info.export_resources_configuration(


### PR DESCRIPTION
## Summary by Sourcery

Fix various typos in test code and fixtures

Tests:
- Rename mock_load_pcsd_permisions to mock_load_pcsd_permissions in PCS configuration tests
- Correct side_efect to side_effect in the mocked_module test helper
- Rename test_no_capabilites to test_no_capabilities in resource configuration tests
- Fix spelling of "inventory" in SBD test YAML comment