### PR TITLE
docs(changelog): version 1.25.4 [citest skip]

### DIFF
--- a/.README.html
+++ b/.README.html
@@ -1065,9 +1065,9 @@ class="sourceCode yaml"><code class="sourceCode yaml"><span id="cb9-1"><a href="
 <p>This variable defines resource groups. The items are as follows:</p>
 <ul>
 <li><code>id</code> (mandatory) - ID of a group.</li>
-<li><code>resources</code> (mandatory) - List of the group's resources.
-Each resource is referenced by its ID and the resources must be defined
-in <a
+<li><code>resource_ids</code> (mandatory) - List of the group's
+resources. Each resource is referenced by its ID and the resources must
+be defined in <a
 href="#ha_cluster_resource_primitives"><code>ha_cluster_resource_primitives</code></a>.
 At least one resource must be listed.</li>
 <li><code>meta_attrs</code> (optional) - List of sets of the group's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+[1.25.4] - 2025-08-08
+--------------------
+
+### Other Changes
+
+- refactor: crmsh update for ansible-core 2.19 (#301)
+- style: fix typos (#302)
+
 [1.25.3] - 2025-08-01
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.25.4

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Document the release of version 1.25.4 and update related documentation

Documentation:
- Add changelog entry for version 1.25.4 with refactor and style updates
- Rename 'resources' parameter to 'resource_ids' in the ha_cluster_sbd_options section of .README.html