### PR TITLE
test: clean up certs/keys created by tests

### DIFF
--- a/.ostree/roles-testing.txt
+++ b/.ostree/roles-testing.txt
@@ -1,0 +1,1 @@
+crypto_policies

--- a/tests/collection-requirements.yml
+++ b/tests/collection-requirements.yml
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: MIT
+---
+collections:
+  - fedora.linux_system_roles

--- a/tests/tasks/fixture_psks.yml
+++ b/tests/tasks/fixture_psks.yml
@@ -29,6 +29,14 @@
       changed_when: false
       no_log: true  # this is quite verbose
 
+    - name: Load test variables
+      include_vars:
+        file: vars/rh_distros_vars.yml
+      when: __ha_cluster_is_rh_distro is not defined
+
+    # Seems like pcs/pcsd is not happy with mldsa65 on RHEL 9,
+    # even though it's supported by openssl.
+    # So we use rsa:2048 instead.
     - name: Generate a self signed pcsd cert and the pcsd key
       command: >-
         openssl req -x509 -newkey {{ key_algo }} -nodes
@@ -38,6 +46,7 @@
       changed_when: false
       vars:
         key_algo: "{{ 'mldsa65' if 'MLDSA65' in openssl_algorithms.stdout
+          and __ha_cluster_is_rh_distro and ansible_facts['distribution_major_version'] | int > 9
           else 'rsa:2048' }}"
 
     - name: Generate corosync key
@@ -57,3 +66,21 @@
         content: "{{ lookup('pipe', 'openssl rand -base64 512') | b64decode }}"
         dest: "{{ __test_fence_xvm_key_path }}"
         mode: "0400"
+
+# https://issues.redhat.com/browse/RHEL-107877
+# el9 needs crypto-policies to be able to use PQC
+- name: Ensure managed node is able to use PQC
+  include_role:
+    name: fedora.linux_system_roles.crypto_policies
+  vars:
+    crypto_policies_policy: DEFAULT:PQ
+  when:
+    - __ha_cluster_is_rh_distro | bool
+    - ansible_facts['distribution_major_version'] | int == 9
+
+- name: Set variables needed for cleanup
+  set_fact:
+    # We need to reset this after the test is done
+    __crypto_policies_policy: "{{ crypto_policies_active | d('')
+      if __ha_cluster_is_rh_distro and ansible_facts['distribution_major_version'] | int == 9
+      else '' }}"

--- a/tests/tests_cluster_basic_custom_pcsd_tls.yml
+++ b/tests/tests_cluster_basic_custom_pcsd_tls.yml
@@ -80,10 +80,43 @@
 
         - name: Check firewall and selinux state
           include_tasks: tasks/check_firewall_selinux.yml
+
+      rescue:
+        - name: Dump journal, logs
+          shell: |
+            set -x
+            exec 1>&2
+            journalctl -ex
+            for file in /var/log/pcsd/*.log; do
+              echo "--- $file ---"
+              cat "$file"
+            done
+            for file in /var/log/pacemaker/*.log; do
+              echo "--- $file ---"
+              cat "$file"
+            done
+          changed_when: false
+          failed_when: true
+
       always:
+        - name: Remove pcsd TLS certificate and key files
+          file:
+            path: "{{ item }}"
+            state: absent
+          loop:
+            - /var/lib/pcsd/pcsd.crt
+            - /var/lib/pcsd/pcsd.key
+
         - name: Clean up work directory
           file:
             path: "{{ __ha_cluster_work_dir.path }}"
             state: absent
           delegate_to: localhost
           run_once: true  # noqa: run_once[task]
+
+        - name: Reset crypto policies
+          include_role:
+            name: fedora.linux_system_roles.crypto_policies
+          vars:
+            crypto_policies_policy: "{{ __crypto_policies_policy }}"
+          when: __crypto_policies_policy | d('') | length > 0

--- a/tests/tests_cluster_basic_custom_pcsd_tls_cert_role.yml
+++ b/tests/tests_cluster_basic_custom_pcsd_tls_cert_role.yml
@@ -13,6 +13,14 @@
     - name: Run test
       tags: tests::verify
       block:
+        - name: Remove pcsd TLS certificate and key files
+          file:
+            path: "{{ item }}"
+            state: absent
+          loop:
+            - /var/lib/pcsd/pcsd.crt
+            - /var/lib/pcsd/pcsd.key
+
         - name: Set up test environment
           include_role:
             name: linux-system-roles.ha_cluster
@@ -48,3 +56,17 @@
 
         - name: Check firewall and selinux state
           include_tasks: tasks/check_firewall_selinux.yml
+
+      always:
+        - name: Stop tracking certificate
+          # note - configure-shell.yml overrides the certificate name
+          command: getcert stop-tracking -f /var/lib/pcsd/pcsd.crt
+          changed_when: false
+
+        - name: Remove pcsd TLS certificate and key files
+          file:
+            path: "{{ item }}"
+            state: absent
+          loop:
+            - /var/lib/pcsd/pcsd.crt
+            - /var/lib/pcsd/pcsd.key

--- a/tests/tests_cluster_basic_existing_psks.yml
+++ b/tests/tests_cluster_basic_existing_psks.yml
@@ -212,10 +212,29 @@
 
         - name: Check firewall and selinux state
           include_tasks: tasks/check_firewall_selinux.yml
+
       always:
+        - name: Ensure keys/certs are removed
+          file:
+            path: "{{ item }}"
+            state: absent
+          loop:
+            - /etc/corosync/authkey
+            - /etc/pacemaker/authkey
+            - /etc/cluster/fence_xvm.key
+            - /var/lib/pcsd/pcsd.crt
+            - /var/lib/pcsd/pcsd.key
+
         - name: Clean up work directory
           file:
             path: "{{ __ha_cluster_work_dir.path }}"
             state: absent
           delegate_to: localhost
           run_once: true  # noqa: run_once[task]
+
+        - name: Reset crypto policies
+          include_role:
+            name: fedora.linux_system_roles.crypto_policies
+          vars:
+            crypto_policies_policy: "{{ __crypto_policies_policy }}"
+          when: __crypto_policies_policy | d('') | length > 0

--- a/tests/tests_cluster_basic_new_psks.yml
+++ b/tests/tests_cluster_basic_new_psks.yml
@@ -180,10 +180,29 @@
 
         - name: Check firewall and selinux state
           include_tasks: tasks/check_firewall_selinux.yml
+
       always:
+        - name: Ensure keys/certs are removed
+          file:
+            path: "{{ item }}"
+            state: absent
+          loop:
+            - /etc/corosync/authkey
+            - /etc/pacemaker/authkey
+            - /etc/cluster/fence_xvm.key
+            - /var/lib/pcsd/pcsd.crt
+            - /var/lib/pcsd/pcsd.key
+
         - name: Clean up work directory
           file:
             path: "{{ __ha_cluster_work_dir.path }}"
             state: absent
           delegate_to: localhost
           run_once: true  # noqa: run_once[task]
+
+        - name: Reset crypto policies
+          include_role:
+            name: fedora.linux_system_roles.crypto_policies
+          vars:
+            crypto_policies_policy: "{{ __crypto_policies_policy }}"
+          when: __crypto_policies_policy | d('') | length > 0


### PR DESCRIPTION
We are seeing test failures on some platforms caused by leftover keys and certs.
Make sure to clean these up, and make sure the test that uses the
certificate system role starts with no certs/keys.

In addition - on el9 systems we need to set the crypto policy to be able
to use Post Quantum Crypto (PQC) in tests.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Clean up all test-generated certificates, keys, and authkeys before and after tests to eliminate leftover artifacts and prevent intermittent failures; add failure-rescue steps for log collection; and refine PSKS fixture key generation for distro compatibility

Bug Fixes:
- Remove leftover pcsd TLS certificates, keys, and PSKS authkeys in multiple test playbooks to fix intermittent failures

Enhancements:
- Introduce rescue tasks in tests to dump systemd, pcsd, and pacemaker logs on failure
- Load distribution variables in the PSKS fixture and default to rsa:2048 when mldsa65 is unsupported

Tests:
- Stop getcert tracking of the pcsd TLS certificate in cert-role tests to avoid stale tracking