### PR TITLE
docs(changelog): version 1.25.5 [citest skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+[1.25.5] - 2025-08-18
+--------------------
+
+### Other Changes
+
+- test: clean up certs/keys created by tests (#304)
+
 [1.25.4] - 2025-08-08
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.25.5

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Prepare for v1.25.5 release by updating changelog and release documentation

Documentation:
- Add [1.25.5] release entry dated 2025-08-18
- Document test cleanup of certificates and keys (#304) in changelog
- Update README.html to reference version 1.25.5