### PR TITLE
feat: export stonith levels

### DIFF
--- a/.sanity-ansible-ignore-2.14.txt
+++ b/.sanity-ansible-ignore-2.14.txt
@@ -41,6 +41,7 @@ plugins/module_utils/ha_cluster_lsr/info/exporter_package/nvset.py compile-2.7!s
 plugins/module_utils/ha_cluster_lsr/info/exporter_package/resource_defaults.py compile-2.7!skip
 plugins/module_utils/ha_cluster_lsr/info/exporter_package/resource_set.py compile-2.7!skip
 plugins/module_utils/ha_cluster_lsr/info/exporter_package/resources.py compile-2.7!skip
+plugins/module_utils/ha_cluster_lsr/info/exporter_package/stonith_levels.py compile-2.7!skip
 plugins/module_utils/ha_cluster_lsr/info/exporter_package/various.py compile-2.7!skip
 plugins/module_utils/ha_cluster_lsr/info/exporter_package/wrap_src.py compile-2.7!skip
 plugins/module_utils/ha_cluster_lsr/info/loader.py compile-3.5!skip
@@ -59,12 +60,14 @@ plugins/module_utils/ha_cluster_lsr/info/exporter_package/nvset.py import-2.7!sk
 plugins/module_utils/ha_cluster_lsr/info/exporter_package/resource_defaults.py import-2.7!skip
 plugins/module_utils/ha_cluster_lsr/info/exporter_package/resource_set.py import-2.7!skip
 plugins/module_utils/ha_cluster_lsr/info/exporter_package/resources.py import-2.7!skip
+plugins/module_utils/ha_cluster_lsr/info/exporter_package/stonith_levels.py import-2.7!skip
 plugins/module_utils/ha_cluster_lsr/info/exporter_package/various.py import-2.7!skip
 plugins/module_utils/ha_cluster_lsr/info/exporter_package/wrap_src.py import-2.7!skip
 plugins/module_utils/ha_cluster_lsr/info/exporter.py import-3.5!skip
 plugins/module_utils/ha_cluster_lsr/info/loader.py import-3.5!skip
 plugins/module_utils/ha_cluster_lsr/info/exporter_package/corosync_conf.py import-3.5!skip
 plugins/module_utils/ha_cluster_lsr/info/exporter_package/resources.py import-3.5!skip
+plugins/module_utils/ha_cluster_lsr/info/exporter_package/stonith_levels.py import-3.5!skip
 plugins/module_utils/ha_cluster_lsr/info/exporter_package/various.py import-3.5!skip
 plugins/module_utils/ha_cluster_lsr/info/exporter_package/wrap_src.py import-3.5!skip
 plugins/module_utils/ha_cluster_lsr/info/exporter_package/cluster_properties.py import-3.5!skip

--- a/.sanity-ansible-ignore-2.16.txt
+++ b/.sanity-ansible-ignore-2.16.txt
@@ -47,6 +47,8 @@ plugins/module_utils/ha_cluster_lsr/info/exporter_package/resource_set.py compil
 plugins/module_utils/ha_cluster_lsr/info/exporter_package/resource_set.py import-2.7!skip
 plugins/module_utils/ha_cluster_lsr/info/exporter_package/resources.py compile-2.7!skip
 plugins/module_utils/ha_cluster_lsr/info/exporter_package/resources.py import-2.7!skip
+plugins/module_utils/ha_cluster_lsr/info/exporter_package/stonith_levels.py compile-2.7!skip
+plugins/module_utils/ha_cluster_lsr/info/exporter_package/stonith_levels.py import-2.7!skip
 plugins/module_utils/ha_cluster_lsr/info/exporter_package/various.py compile-2.7!skip
 plugins/module_utils/ha_cluster_lsr/info/exporter_package/various.py import-2.7!skip
 plugins/module_utils/ha_cluster_lsr/info/exporter_package/wrap_src.py compile-2.7!skip

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ An Ansible role for managing High Availability Clustering.
   * stonith and resources
   * resource defaults and resource operation defaults
   * resource constraints
+  * stonith levels, also known as fencing topology
 * The role can be used to configure a non-running container or VM image.
   However, in this mode, the role is limited to only install cluster packages.
 
@@ -1624,6 +1625,7 @@ may not be present in the export.
   * [`ha_cluster_constraints_colocation`](#ha_cluster_constraints_colocation)
   * [`ha_cluster_constraints_order`](#ha_cluster_constraints_order)
   * [`ha_cluster_constraints_ticket`](#ha_cluster_constraints_ticket)
+  * [`ha_cluster_stonith_levels`](#ha_cluster_stonith_levels)
 
 * Following variables are never present in the export (consult the role
   documentation for impact of the variables missing when running the role):

--- a/library/ha_cluster_info.py
+++ b/library/ha_cluster_info.py
@@ -152,6 +152,7 @@ class Capability(Enum):
         "pcmk.properties.operation-defaults.config.output-formats"
     )
     CONSTRAINTS_OUTPUT = "pcmk.constraint.config.output-formats"
+    STONITH_LEVELS_OUTPUT = "pcmk.stonith.levels.config.output-formats"
 
 
 def get_cmd_runner(module: AnsibleModule) -> loader.CommandRunner:
@@ -411,6 +412,28 @@ def export_constraints_configuration(
     return result
 
 
+def export_stonith_levels_configuration(
+    module: AnsibleModule, pcs_capabilities: List[str]
+) -> Dict[str, Any]:
+    """
+    Export existing HA cluster stonith levels
+    """
+
+    if Capability.STONITH_LEVELS_OUTPUT.value not in pcs_capabilities:
+        return dict()
+
+    cmd_runner = get_cmd_runner(module)
+    stonith_levels = loader.get_stonith_levels_configuration(cmd_runner)
+
+    result: dict[str, Any] = dict()
+
+    levels = exporter.export_stonith_levels(stonith_levels)
+    if levels:
+        result["ha_cluster_stonith_levels"] = levels
+
+    return result
+
+
 def get_pcs_capabilities(module: AnsibleModule) -> List[str]:
     """
     Extract pcsd pcs_capabilities from pcs version info
@@ -457,6 +480,9 @@ def main() -> None:
             )
             ha_cluster_result.update(
                 **export_constraints_configuration(module, pcs_capabilities)
+            )
+            ha_cluster_result.update(
+                **export_stonith_levels_configuration(module, pcs_capabilities)
             )
             ha_cluster_result["ha_cluster_cluster_present"] = True
         else:

--- a/library/ha_cluster_info.py
+++ b/library/ha_cluster_info.py
@@ -33,6 +33,8 @@ requirements:
     - pcs-0.12.0 or 0.11.8 or newer for exporting resources defaults and
       resources operation defaults
     - pcs-0.12.0 or pcs-0.11.6 or newer for exporting constraints configuration
+    - pcs-0.12.0 or pcs-0.11.9 or newer for exporting stonith levels
+      configuration
     - python3-firewall for exporting ha_cluster_manage_firewall
     - python3-policycoreutils for exporting ha_cluster_manage_selinux
     - python 3.6 or newer
@@ -82,6 +84,7 @@ ha_cluster:
         - ha_cluster_constraints_colocation
         - ha_cluster_constraints_order
         - ha_cluster_constraints_ticket
+        - ha_cluster_stonith_levels
         - HORIZONTALLINE
         - Following variables are required for running ha_cluster role but are
           never present in this module output

--- a/module_utils/ha_cluster_lsr/info/exporter.py
+++ b/module_utils/ha_cluster_lsr/info/exporter.py
@@ -44,6 +44,9 @@ from .exporter_package.resources import (
     export_resource_group_list,
     export_resource_primitive_list,
 )
+from .exporter_package.stonith_levels import (
+    export_stonith_levels,
+)
 from .exporter_package.various import (
     export_enable_repos_ha,
     export_enable_repos_rs,

--- a/module_utils/ha_cluster_lsr/info/exporter_package/stonith_levels.py
+++ b/module_utils/ha_cluster_lsr/info/exporter_package/stonith_levels.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2024 Red Hat, Inc.
+# SPDX-License-Identifier: MIT
+
+# make ansible-test happy, even though the module requires Python 3
+from __future__ import absolute_import, division, print_function
+
+# make ansible-test happy, even though the module requires Python 3
+# pylint: disable=invalid-name
+__metaclass__ = type
+
+from typing import Any, Dict, List
+
+from .wrap_src import SrcDict, wrap_src_for_rich_report
+
+
+@wrap_src_for_rich_report(dict(stonith_levels="stonith levels configuration"))
+def export_stonith_levels(stonith_levels: SrcDict) -> List[Dict[str, Any]]:
+    """
+    Export stonith levels from `pcs stonith level config --output-format=json`
+    output
+    """
+    return (
+        [
+            {
+                "level": item["index"],
+                "target": item["target"],
+                "resource_ids": list(item["devices"]),
+            }
+            for item in stonith_levels["target_node"]
+        ]
+        + [
+            {
+                "level": item["index"],
+                "target_pattern": item["target_pattern"],
+                "resource_ids": list(item["devices"]),
+            }
+            for item in stonith_levels["target_regex"]
+        ]
+        + [
+            {
+                "level": item["index"],
+                "target_attribute": item["target_attribute"],
+                **(
+                    {"target_value": item["target_value"]}
+                    if item["target_value"]
+                    else {}
+                ),
+                "resource_ids": list(item["devices"]),
+            }
+            for item in stonith_levels["target_attribute"]
+        ]
+    )

--- a/module_utils/ha_cluster_lsr/info/loader.py
+++ b/module_utils/ha_cluster_lsr/info/loader.py
@@ -350,6 +350,16 @@ def get_constraints_configuration(
     )
 
 
+def get_stonith_levels_configuration(
+    run_command: CommandRunner,
+) -> Dict[str, Any]:
+    """Get stonith levels configuration from pcs"""
+    return _call_pcs_cli(
+        run_command,
+        ["stonith", "level", "config", "--output-format=json"],
+    )
+
+
 def get_pcs_version_info(run_command: CommandRunner) -> Tuple[str, List[str]]:
     """
     Get pcs version and list of capabilities

--- a/tests/tests_cib_stonith_levels.yml
+++ b/tests/tests_cib_stonith_levels.yml
@@ -9,6 +9,27 @@
       tags:
         - tests::booted
         - tests::verify
+      vars:
+        ha_cluster_stonith_levels:
+          - level: 1
+            target: "{{ __test_first_node }}"
+            resource_ids:
+              - fence1
+          - level: 2
+            target_pattern: node-\d+
+            resource_ids:
+              - fence2
+          - level: 3
+            target_attribute: some-name
+            resource_ids:
+              - fence1
+              - fence2
+          - level: 4
+            target_attribute: some-name
+            target_value: some-value
+            resource_ids:
+              - fence2
+              - fence1
       block:
         - name: Skip test in bootc mode
           include_tasks: tasks/skip_if_bootc.yml
@@ -31,31 +52,12 @@
             ha_cluster_cluster_name: test-cluster
             ha_cluster_manage_firewall: true
             ha_cluster_manage_selinux: true
+            ha_cluster_export_configuration: true
             ha_cluster_resource_primitives:
               - id: fence1
                 agent: 'stonith:fence_kdump'
               - id: fence2
                 agent: 'stonith:fence_kdump'
-            ha_cluster_stonith_levels:
-              - level: 1
-                target: "{{ __test_first_node }}"
-                resource_ids:
-                  - fence1
-              - level: 2
-                target_pattern: node-\d+
-                resource_ids:
-                  - fence2
-              - level: 3
-                target_attribute: some-name
-                resource_ids:
-                  - fence1
-                  - fence2
-              - level: 4
-                target_attribute: some-name
-                target_value: some-value
-                resource_ids:
-                  - fence2
-                  - fence1
 
         - name: Fetch versions of cluster components
           include_tasks: tasks/fetch_versions.yml
@@ -169,3 +171,27 @@
 
         - name: Check firewall and selinux state
           include_tasks: tasks/check_firewall_selinux.yml
+
+        - name: Check exported stonith levels configuration
+          when:
+            - '"pcmk.stonith.levels.config.output-formats" in __test_pcs_capabilities'
+          vars:
+            __test_exported_config:
+              ha_cluster_stonith_levels: >-
+                {{ ha_cluster_facts.ha_cluster_stonith_levels }}
+            __test_expected_config:
+              ha_cluster_stonith_levels: >-
+                {{ ha_cluster_stonith_levels }}
+          block:
+            - name: Print exported stonith levels configuration
+              debug:
+                var: __test_exported_config
+
+            - name: Print expected stonith levels configuration
+              debug:
+                var: __test_expected_config
+
+            - name: Compare expected and exported stonith levels configuration
+              assert:
+                that:
+                  - __test_exported_config == __test_expected_config

--- a/tests/tests_cib_stonith_levels.yml
+++ b/tests/tests_cib_stonith_levels.yml
@@ -5,6 +5,12 @@
   vars_files: vars/main.yml
 
   tasks:
+    - name: Find first node name
+      set_fact:
+        __test_first_node: "{{
+            (ansible_play_hosts_all | length == 1)
+            | ternary('localhost', ansible_play_hosts[0]) }}"
+
     - name: Run test
       tags:
         - tests::booted
@@ -38,12 +44,6 @@
           include_role:
             name: linux-system-roles.ha_cluster
             tasks_from: test_setup.yml
-
-        - name: Find first node name
-          set_fact:
-            __test_first_node: "{{
-                (ansible_play_hosts_all | length == 1)
-                | ternary('localhost', ansible_play_hosts[0]) }}"
 
         - name: Run HA Cluster role
           include_tasks: tasks/run_role_with_clear_facts.yml

--- a/tests/unit/fixture_stonith_levels.py
+++ b/tests/unit/fixture_stonith_levels.py
@@ -1,0 +1,5 @@
+EMPTY_STONITH_LEVELS = {  # type: ignore
+    "target_node": [],
+    "target_regex": [],
+    "target_attribute": [],
+}

--- a/tests/unit/test_ha_cluster_info_stonith_levels.py
+++ b/tests/unit/test_ha_cluster_info_stonith_levels.py
@@ -1,0 +1,146 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2024 Red Hat, Inc.
+# SPDX-License-Identifier: MIT
+
+# pylint: disable=missing-class-docstring
+# pylint: disable=missing-function-docstring
+
+import json
+from unittest import TestCase, mock
+
+from .fixture_stonith_levels import EMPTY_STONITH_LEVELS
+from .ha_cluster_info import ha_cluster_info, mocked_module
+
+CMD_OPTIONS = dict(environ_update={"LC_ALL": "C"}, check_rc=False)
+PCS_CMD = ["pcs", "stonith", "level", "config", "--output-format=json"]
+CMD_STONITH_LEVELS_CONF = mock.call(PCS_CMD, **CMD_OPTIONS)
+
+
+class ExportStonithLevelsConfiguration(TestCase):
+    maxDiff = None
+
+    def test_success(self) -> None:
+        stonith_levels_data = {
+            "target_node": [
+                {
+                    "id": "fl-node1-1",
+                    "target": "node1",
+                    "index": 1,
+                    "devices": ["fence_xvm1", "fence_xvm2"],
+                },
+                {
+                    "id": "fl-node1-2",
+                    "target": "node1",
+                    "index": 2,
+                    "devices": ["fence_kdump"],
+                },
+            ],
+            "target_regex": [
+                {
+                    "id": "fl-regex-1",
+                    "target_pattern": "node-.*",
+                    "index": 1,
+                    "devices": ["fence_xvm3"],
+                },
+            ],
+            "target_attribute": [
+                {
+                    "id": "fl-attr-1",
+                    "target_attribute": "rack",
+                    "target_value": "1",
+                    "index": 1,
+                    "devices": ["fence_xvm4"],
+                },
+            ],
+        }
+        with mocked_module(
+            [
+                (
+                    CMD_STONITH_LEVELS_CONF,
+                    (0, json.dumps(stonith_levels_data), ""),
+                ),
+            ]
+        ) as module_mock:
+            self.assertEqual(
+                ha_cluster_info.export_stonith_levels_configuration(
+                    module_mock,
+                    [
+                        ha_cluster_info.Capability.STONITH_LEVELS_OUTPUT.value,
+                    ],
+                ),
+                {
+                    "ha_cluster_stonith_levels": [
+                        {
+                            "level": 1,
+                            "target": "node1",
+                            "resource_ids": ["fence_xvm1", "fence_xvm2"],
+                        },
+                        {
+                            "level": 2,
+                            "target": "node1",
+                            "resource_ids": ["fence_kdump"],
+                        },
+                        {
+                            "level": 1,
+                            "target_pattern": "node-.*",
+                            "resource_ids": ["fence_xvm3"],
+                        },
+                        {
+                            "level": 1,
+                            "target_attribute": "rack",
+                            "target_value": "1",
+                            "resource_ids": ["fence_xvm4"],
+                        },
+                    ],
+                },
+            )
+
+    def test_success_empty(self) -> None:
+        with mocked_module(
+            [
+                (
+                    CMD_STONITH_LEVELS_CONF,
+                    (0, json.dumps(EMPTY_STONITH_LEVELS), ""),
+                ),
+            ]
+        ) as module_mock:
+            self.assertEqual(
+                ha_cluster_info.export_stonith_levels_configuration(
+                    module_mock,
+                    [
+                        ha_cluster_info.Capability.STONITH_LEVELS_OUTPUT.value,
+                    ],
+                ),
+                {},
+            )
+
+    def test_no_capabilities(self) -> None:
+        with mocked_module([]) as module_mock:
+            self.assertEqual(
+                ha_cluster_info.export_stonith_levels_configuration(
+                    module_mock, pcs_capabilities=[]
+                ),
+                {},
+            )
+
+    def test_pcs_cmd_fail(self) -> None:
+        with self.assertRaises(ha_cluster_info.loader.CliCommandError) as cm:
+            with mocked_module(
+                [(CMD_STONITH_LEVELS_CONF, (1, "", "Error"))]
+            ) as module_mock:
+                ha_cluster_info.export_stonith_levels_configuration(
+                    module_mock,
+                    [
+                        ha_cluster_info.Capability.STONITH_LEVELS_OUTPUT.value,
+                    ],
+                )
+        self.assertEqual(
+            cm.exception.kwargs,
+            dict(
+                pcs_command=PCS_CMD,
+                stdout="",
+                stderr="Error",
+                rc=1,
+            ),
+        )

--- a/tests/unit/test_info_exporter_stonith_levels.py
+++ b/tests/unit/test_info_exporter_stonith_levels.py
@@ -1,0 +1,242 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2024 Red Hat, Inc.
+# SPDX-License-Identifier: MIT
+
+# pylint: disable=missing-class-docstring
+# pylint: disable=missing-function-docstring
+
+from unittest import TestCase
+
+from .fixture_stonith_levels import EMPTY_STONITH_LEVELS
+from .ha_cluster_info import exporter
+
+
+class ExportStonithLevels(TestCase):
+    maxDiff = None
+
+    def test_uses_standard_invalid_src_dealing(self) -> None:
+        stonith_levels_data = {}  # type: ignore
+        with self.assertRaises(exporter.InvalidSrc) as cm:
+            exporter.export_stonith_levels(stonith_levels_data)
+        self.assertEqual(
+            cm.exception.kwargs,
+            dict(
+                data=stonith_levels_data,
+                data_desc="stonith levels configuration",
+                issue_location="",
+                issue_desc="Missing key 'target_node'",
+            ),
+        )
+
+    def test_empty_stonith_levels(self) -> None:
+        self.assertEqual(
+            [], exporter.export_stonith_levels(EMPTY_STONITH_LEVELS)
+        )
+
+    def test_export_target_node_single(self) -> None:
+        self.assertEqual(
+            [
+                {
+                    "level": 1,
+                    "target": "node1",
+                    "resource_ids": ["fence_xvm1"],
+                },
+            ],
+            exporter.export_stonith_levels(
+                {
+                    **EMPTY_STONITH_LEVELS,
+                    "target_node": [
+                        {
+                            "id": "fl-node1-1",
+                            "target": "node1",
+                            "index": 1,
+                            "devices": ["fence_xvm1"],
+                        },
+                    ],
+                }
+            ),
+        )
+
+    def test_export_target_node_multiple(self) -> None:
+        self.assertEqual(
+            [
+                {
+                    "level": 1,
+                    "target": "node1",
+                    "resource_ids": ["fence_xvm1", "fence_xvm2"],
+                },
+                {
+                    "level": 2,
+                    "target": "node1",
+                    "resource_ids": ["fence_kdump"],
+                },
+                {
+                    "level": 1,
+                    "target": "node2",
+                    "resource_ids": ["fence_xvm1"],
+                },
+            ],
+            exporter.export_stonith_levels(
+                {
+                    **EMPTY_STONITH_LEVELS,
+                    "target_node": [
+                        {
+                            "id": "fl-node1-1",
+                            "target": "node1",
+                            "index": 1,
+                            "devices": ["fence_xvm1", "fence_xvm2"],
+                        },
+                        {
+                            "id": "fl-node1-2",
+                            "target": "node1",
+                            "index": 2,
+                            "devices": ["fence_kdump"],
+                        },
+                        {
+                            "id": "fl-node2-1",
+                            "target": "node2",
+                            "index": 1,
+                            "devices": ["fence_xvm1"],
+                        },
+                    ],
+                }
+            ),
+        )
+
+    def test_export_target_regex(self) -> None:
+        self.assertEqual(
+            [
+                {
+                    "level": 1,
+                    "target_pattern": "node-.*",
+                    "resource_ids": ["fence_xvm1"],
+                },
+                {
+                    "level": 2,
+                    "target_pattern": "node-.*",
+                    "resource_ids": ["fence_kdump"],
+                },
+            ],
+            exporter.export_stonith_levels(
+                {
+                    **EMPTY_STONITH_LEVELS,
+                    "target_regex": [
+                        {
+                            "id": "fl-regex-1",
+                            "target_pattern": "node-.*",
+                            "index": 1,
+                            "devices": ["fence_xvm1"],
+                        },
+                        {
+                            "id": "fl-regex-2",
+                            "target_pattern": "node-.*",
+                            "index": 2,
+                            "devices": ["fence_kdump"],
+                        },
+                    ],
+                }
+            ),
+        )
+
+    def test_export_target_attribute(self) -> None:
+        self.assertEqual(
+            [
+                {
+                    "level": 1,
+                    "target_attribute": "rack",
+                    "target_value": "1",
+                    "resource_ids": ["fence_xvm1"],
+                },
+            ],
+            exporter.export_stonith_levels(
+                {
+                    **EMPTY_STONITH_LEVELS,
+                    "target_attribute": [
+                        {
+                            "id": "fl-attr-1",
+                            "target_attribute": "rack",
+                            "target_value": "1",
+                            "index": 1,
+                            "devices": ["fence_xvm1"],
+                        },
+                    ],
+                }
+            ),
+        )
+
+    def test_export_target_attribute_empty_value(self) -> None:
+        self.assertEqual(
+            [
+                {
+                    "level": 1,
+                    "target_attribute": "rack",
+                    "resource_ids": ["fence_xvm1"],
+                },
+            ],
+            exporter.export_stonith_levels(
+                {
+                    **EMPTY_STONITH_LEVELS,
+                    "target_attribute": [
+                        {
+                            "id": "fl-attr-1",
+                            "target_attribute": "rack",
+                            "target_value": "",
+                            "index": 1,
+                            "devices": ["fence_xvm1"],
+                        },
+                    ],
+                }
+            ),
+        )
+
+    def test_export_mixed(self) -> None:
+        self.assertEqual(
+            [
+                {
+                    "level": 1,
+                    "target": "node1",
+                    "resource_ids": ["fence_xvm1"],
+                },
+                {
+                    "level": 1,
+                    "target_pattern": "node-.*",
+                    "resource_ids": ["fence_xvm2"],
+                },
+                {
+                    "level": 1,
+                    "target_attribute": "rack",
+                    "target_value": "1",
+                    "resource_ids": ["fence_kdump"],
+                },
+            ],
+            exporter.export_stonith_levels(
+                {
+                    "target_node": [
+                        {
+                            "id": "fl-node1-1",
+                            "target": "node1",
+                            "index": 1,
+                            "devices": ["fence_xvm1"],
+                        },
+                    ],
+                    "target_regex": [
+                        {
+                            "id": "fl-regex-1",
+                            "target_pattern": "node-.*",
+                            "index": 1,
+                            "devices": ["fence_xvm2"],
+                        },
+                    ],
+                    "target_attribute": [
+                        {
+                            "id": "fl-attr-1",
+                            "target_attribute": "rack",
+                            "target_value": "1",
+                            "index": 1,
+                            "devices": ["fence_kdump"],
+                        },
+                    ],
+                }
+            ),
+        )


### PR DESCRIPTION
Enhancement:
Add stonith levels to ha_cluster_info module exporting current cluster configuration.

Reason:
This is the next step in implementing an info module which exports cluster configuration in a variables structure in the same format as ha_cluster role accepts.

Result:
Variables have been added to the export:
* `ha_cluster_stonith_levels`

Issue Tracker Tickets (Jira or BZ if any):
https://redhat.atlassian.net/browse/RHEL-46232

## Summary by Sourcery

Export existing cluster stonith levels through the ha_cluster_info module and verify they round-trip with the role configuration.

New Features:
- Expose ha_cluster_stonith_levels from existing cluster configuration via ha_cluster_info when pcs supports stonith level JSON output.

Enhancements:
- Extend pcs capability detection and loader/exporter logic to handle stonith level configuration, including mapping pcs JSON output into role variable structure.

Documentation:
- Document stonith levels (fencing topology) as part of the configuration exported by ha_cluster_info.

Tests:
- Add integration and unit tests to validate stonith levels export, including various targeting modes and error handling for pcs failures.