### PR TITLE
feat: Parametrize no_log usage in ha_cluster role

### DIFF
--- a/README.md
+++ b/README.md
@@ -1490,6 +1490,20 @@ changed.
 You may take a look at [an
 example](#configuring-a-cluster-using-a-quorum-device).
 
+#### `ha_cluster_secure_logging`
+
+boolean, default: `true`
+
+If `true`, suppress potentially sensitive output from tasks that handle
+credentials, secrets, and other sensitive data by setting `no_log: true` on
+those tasks. This prevents passwords, API tokens, preshared keys, and similar
+sensitive information from appearing in Ansible logs and console output.
+
+If you need to debug issues with credential handling or secret management, you
+can temporarily set `ha_cluster_secure_logging: false` to see the full output
+from these tasks. However, be aware that this may expose sensitive information
+in logs, so it should only be used in development or troubleshooting scenarios.
+
 ### Inventory
 
 #### Nodes' names and addresses

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -84,3 +84,7 @@ ha_cluster_export_configuration: false
 # This allows cluster administration with non-root user.
 # ha_cluster_admin_user_name: ''
 # ha_cluster_admin_user_group: ''
+
+# If true, suppress potentially sensitive output from tasks that
+# handle credentials, secrets, and other sensitive data.
+ha_cluster_secure_logging: true

--- a/tasks/shell_common/cluster-enable-disable.yml
+++ b/tasks/shell_common/cluster-enable-disable.yml
@@ -18,6 +18,7 @@
 
 - name: Get services status - detect SBD
   ansible.builtin.service_facts:
+  no_log: "{{ ansible_verbosity < 2 }}"
 
 - name: Enable or disable SBD
   ansible.builtin.service:

--- a/tasks/shell_common/presharedkey.yml
+++ b/tasks/shell_common/presharedkey.yml
@@ -25,7 +25,7 @@
       register: __ha_cluster_preshared_key_slurp_controller
       when: __ha_cluster_preshared_key_stat_controller.stat.exists
       # Prevent key contents to be printed to the output
-      no_log: true
+      no_log: "{{ ha_cluster_secure_logging }}"
 
     - name: Use the slurped key from the controller {{ preshared_key_label }}
       ansible.builtin.set_fact:
@@ -33,14 +33,14 @@
           "{{ __ha_cluster_preshared_key_slurp_controller.content }}"
       when: __ha_cluster_preshared_key_stat_controller.stat.exists
       # Prevent key contents to be printed to the output
-      no_log: true
+      no_log: "{{ ha_cluster_secure_logging }}"
 
 - name: Generate random key {{ preshared_key_label }}
   when:
     - not (preshared_key_src is string and preshared_key_src | length > 1)
   run_once: true  # noqa: run_once[task]
   # Prevent key contents to be printed to the output
-  no_log: true
+  no_log: "{{ ha_cluster_secure_logging }}"
   block:
     - name: Generate key using OpenSSL {{ preshared_key_label }}
       ansible.builtin.command:
@@ -69,7 +69,7 @@
       register: __ha_cluster_preshared_key_slurp
       when: __ha_cluster_preshared_key_stat.stat.exists
       # Prevent key contents to be printed to the output
-      no_log: true
+      no_log: "{{ ha_cluster_secure_logging }}"
 
     - name: Use the slurped key from cluster nodes {{ preshared_key_label }}
       ansible.builtin.set_fact:
@@ -77,7 +77,7 @@
           "{{ __ha_cluster_preshared_key_slurp.content }}"
       when: __ha_cluster_preshared_key_stat.stat.exists
       # Prevent key contents to be printed to the output
-      no_log: true
+      no_log: "{{ ha_cluster_secure_logging }}"
       # Following variables set the fact for all nodes
       delegate_facts: true
       delegate_to: "{{ item }}"

--- a/tasks/shell_common/selinux.yml
+++ b/tasks/shell_common/selinux.yml
@@ -3,6 +3,7 @@
 
 - name: Populate service facts
   ansible.builtin.service_facts:
+  no_log: "{{ ansible_verbosity < 2 }}"
 
 - name: Manage SELinux
   when:

--- a/tasks/shell_crmsh/cluster-destroy.yml
+++ b/tasks/shell_crmsh/cluster-destroy.yml
@@ -40,6 +40,7 @@
 
 - name: Populate service facts
   ansible.builtin.service_facts:
+  no_log: "{{ ansible_verbosity < 2 }}"
 
 # Conditional added to skip qdevice in case qdevice was not configured
 - name: Stop cluster daemons

--- a/tasks/shell_crmsh/cluster-setup-keys.yml
+++ b/tasks/shell_crmsh/cluster-setup-keys.yml
@@ -17,7 +17,7 @@
     group: root
     mode: '0400'
   register: __ha_cluster_distribute_corosync_authkey
-  no_log: true
+  no_log: "{{ ha_cluster_secure_logging }}"
 
 - name: Get pacemaker authkey
   ansible.builtin.include_tasks:
@@ -36,4 +36,4 @@
     group: haclient
     mode: '0400'
   register: __ha_cluster_distribute_pacemaker_authkey
-  no_log: true
+  no_log: "{{ ha_cluster_secure_logging }}"

--- a/tasks/shell_crmsh/cluster-start-and-reload.yml
+++ b/tasks/shell_crmsh/cluster-start-and-reload.yml
@@ -2,6 +2,7 @@
 ---
 - name: Get services status - detect corosync-qdevice
   ansible.builtin.service_facts:
+  no_log: "{{ ansible_verbosity < 2 }}"
 
 - name: Stop cluster daemons to reload configuration
   ansible.builtin.service:

--- a/tasks/shell_crmsh/preconfigure_hosts.yml
+++ b/tasks/shell_crmsh/preconfigure_hosts.yml
@@ -17,7 +17,7 @@
             {{ ha_cluster_hacluster_password | string | quote }}
       register: __ha_cluster_openssl_call_result
       changed_when: false
-      no_log: true
+      no_log: "{{ ha_cluster_secure_logging }}"
 
     - name: Set hacluster password
       ansible.builtin.user:

--- a/tasks/shell_pcs/cluster-start-and-reload.yml
+++ b/tasks/shell_pcs/cluster-start-and-reload.yml
@@ -20,6 +20,7 @@
 
 - name: Get services status - detect corosync-qdevice
   service_facts:
+  no_log: "{{ ansible_verbosity < 2 }}"
 
 - name: Stop cluster daemons to reload configuration
   service:

--- a/tasks/shell_pcs/preconfigure_hosts.yml
+++ b/tasks/shell_pcs/preconfigure_hosts.yml
@@ -17,7 +17,7 @@
             {{ ha_cluster_hacluster_password | string | quote }}
       register: __ha_cluster_openssl_call_result
       changed_when: false
-      no_log: true
+      no_log: "{{ ha_cluster_secure_logging }}"
 
     - name: Set hacluster password
       ansible.builtin.user:

--- a/tasks/shell_pcs/sbd.yml
+++ b/tasks/shell_pcs/sbd.yml
@@ -143,6 +143,7 @@
 
 - name: Get services status - detect pacemaker
   service_facts:
+  no_log: "{{ ansible_verbosity < 2 }}"
 
 - name: Set stonith-watchdog-timeout cluster property
   vars:


### PR DESCRIPTION
Feature: Introduce the `ha_cluster_secure_logging` variable that defaults to `true` and using verbosity-based logging for facts modules.

Reason: Currently, all sensitive tasks use hard-coded no_log: true, which makes debugging difficult. Users cannot see credential-related output even when troubleshooting authentication or secret management issues. Additionally, service_facts produces verbose output that clutters logs during normal operation.

Result:
  - Tasks handling credentials, secrets, and sensitive data now use no_log: "{{ ha_cluster_secure_logging }}", allowing users to set ha_cluster_secure_logging: false for debugging while maintaining secure defaults (true)
  - service_facts now uses no_log: "{{ ansible_verbosity < 2 }}", hiding verbose output unless -vv or higher verbosity is specified
  - New variable ha_cluster_secure_logging documented in README.md with guidance on when to disable it
  - Users can now debug credential and secret issues without modifying role code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce configurable secure logging for sensitive tasks and verbosity-based logging for service facts in the ha_cluster role.

New Features:
- Add ha_cluster_secure_logging variable to control no_log behavior for tasks handling credentials and other sensitive data.

Enhancements:
- Switch sensitive preshared key and auth key tasks from hard-coded no_log to using the ha_cluster_secure_logging variable.
- Apply verbosity-based no_log to service_facts tasks to reduce log noise at normal verbosity levels.

Documentation:
- Document the ha_cluster_secure_logging variable and guidance on when to disable secure logging in README.md.