### PR TITLE
docs(changelog): version 1.31.0 [citest_skip]

### DIFF
--- a/.README.html
+++ b/.README.html
@@ -236,6 +236,8 @@ id="toc-ha_cluster_acls"><code>ha_cluster_acls</code></a></li>
 id="toc-ha_cluster_alerts"><code>ha_cluster_alerts</code></a></li>
 <li><a href="#ha_cluster_qnetd"
 id="toc-ha_cluster_qnetd"><code>ha_cluster_qnetd</code></a></li>
+<li><a href="#ha_cluster_secure_logging"
+id="toc-ha_cluster_secure_logging"><code>ha_cluster_secure_logging</code></a></li>
 </ul></li>
 <li><a href="#inventory" id="toc-inventory">Inventory</a>
 <ul>
@@ -366,6 +368,8 @@ lost.</li>
 <li>resource defaults and resource operation defaults</li>
 <li>resource constraints</li>
 <li>stonith levels, also known as fencing topology</li>
+<li>Pacemaker node attributes</li>
+<li>node and resource utilization</li>
 </ul></li>
 <li>The role can be used to configure a non-running container or VM
 image. However, in this mode, the role is limited to only install
@@ -1812,6 +1816,20 @@ disrupt qnetd operation.</p>
 configuration will not be changed.</p>
 <p>You may take a look at <a
 href="#configuring-a-cluster-using-a-quorum-device">an example</a>.</p>
+<h3
+id="ha_cluster_secure_logging"><code>ha_cluster_secure_logging</code></h3>
+<p>boolean, default: <code>true</code></p>
+<p>If <code>true</code>, suppress potentially sensitive output from
+tasks that handle credentials, secrets, and other sensitive data by
+setting <code>no_log: true</code> on those tasks. This prevents
+passwords, API tokens, preshared keys, and similar sensitive information
+from appearing in Ansible logs and console output.</p>
+<p>If you need to debug issues with credential handling or secret
+management, you can temporarily set
+<code>ha_cluster_secure_logging: false</code> to see the full output
+from these tasks. However, be aware that this may expose sensitive
+information in logs, so it should only be used in development or
+troubleshooting scenarios.</p>
 <h2 id="inventory">Inventory</h2>
 <h3 id="nodes-names-and-addresses">Nodes' names and addresses</h3>
 <p>Nodes' names and addresses can be configured in
@@ -1950,8 +1968,9 @@ href="#ha_cluster_transport"><code>ha_cluster_transport</code></a></li>
 <li><a href="#ha_cluster_quorum"><code>ha_cluster_quorum</code></a></li>
 <li><a
 href="#ha_cluster_node_options"><code>ha_cluster_node_options</code></a>
-- currently only <code>node_name</code>, <code>corosync_addresses</code>
-and <code>pcs_address</code> are present</li>
+- <code>node_name</code>, <code>corosync_addresses</code>,
+<code>pcs_address</code>, <code>attributes</code> and
+<code>utilization</code></li>
 <li><a
 href="#ha_cluster_resource_primitives"><code>ha_cluster_resource_primitives</code></a></li>
 <li><a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 Changelog
 =========
 
+[1.31.0] - 2026-05-07
+--------------------
+
+### New Features
+
+- feat: export node attributes utilization (#382)
+- feat: Parametrize no_log usage in ha_cluster role (#383)
+
+### Other Changes
+
+- refactor: Restructure task files to enable more differences between shells (#378)
+- ci: bump actions/github-script from 8 to 9 (#381)
+
 [1.30.0] - 2026-04-28
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.31.0

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Document changes for the 1.31.0 release.

New Features:
- Document the new ha_cluster_secure_logging variable and its behavior.
- Describe support for exporting Pacemaker node attributes and utilization via ha_cluster_node_options.

Documentation:
- Update .README.html inventory and limitations sections to mention Pacemaker node attributes and node/resource utilization.
- Regenerate .README.html to include ha_cluster_secure_logging documentation, including defaults and usage guidance.

Chores:
- Add a 1.31.0 entry to CHANGELOG.md summarizing new features and other notable changes.