### PR TITLE
docs(changelog): version 1.31.1 [citest_skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+[1.31.1] - 2026-05-13
+--------------------
+
+### Bug Fixes
+
+- fix: check for corosync-qdevice service in bad state before stopping (#385)
+
 [1.31.0] - 2026-05-07
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.31.1

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Bug Fixes:
- Record the fix for handling corosync-qdevice service in a bad state before stopping it in version 1.31.1.