### PR TITLE
test: fix python unit tests - do not need class name

### DIFF
--- a/tests/unit/test_pcs_api_v2.py
+++ b/tests/unit/test_pcs_api_v2.py
@@ -66,7 +66,7 @@ class Pcs(TestCase):
                     "params": self.cmd_params,
                     "options": to_dict(self.cmd_options),
                 },
-                task_finish_type="TaskFinishType.SUCCESS",
+                task_finish_type="SUCCESS",
                 result={"some": "result"},
                 reports=[],
                 kill_reason=None,

--- a/tests/unit/test_pcs_api_v2_utils.py
+++ b/tests/unit/test_pcs_api_v2_utils.py
@@ -46,7 +46,7 @@ fixture_api_result_command_dict: dict[str, Any] = {
 fixture_api_result_dict_minimal: dict[str, Any] = {
     "task_ident": "identifier",
     "command": fixture_api_result_command_dict,
-    "task_finish_type": str(SUCCESS),
+    "task_finish_type": "SUCCESS",
     "result": None,
     "reports": [],
     "kill_reason": None,

--- a/tests/unit/test_pcs_api_v2_utils.py
+++ b/tests/unit/test_pcs_api_v2_utils.py
@@ -46,7 +46,7 @@ fixture_api_result_command_dict: dict[str, Any] = {
 fixture_api_result_dict_minimal: dict[str, Any] = {
     "task_ident": "identifier",
     "command": fixture_api_result_command_dict,
-    "task_finish_type": str(TaskFinishType.SUCCESS),
+    "task_finish_type": str(SUCCESS),
     "result": None,
     "reports": [],
     "kill_reason": None,
@@ -230,7 +230,7 @@ class ParseApiResponse(TestCase):
             dict(
                 task_ident="identifier",
                 command=fixture_api_result_command_dict,
-                task_finish_type="TaskFinishType.FAIL",
+                task_finish_type="FAIL",
                 result=None,
                 reports=[],
                 kill_reason=None,
@@ -245,7 +245,7 @@ class ParseApiResponse(TestCase):
                     to_dict(
                         fixture.task_result_dto(
                             finish_type=TaskFinishType.KILL,
-                            kill_reason=TaskKillReason.COMPLETION_TIMEOUT,
+                            kill_reason=COMPLETION_TIMEOUT,
                         )
                     )
                 ).encode(),
@@ -256,7 +256,7 @@ class ParseApiResponse(TestCase):
             dict(
                 task_ident="identifier",
                 command=fixture_api_result_command_dict,
-                task_finish_type="TaskFinishType.KILL",
+                task_finish_type="KILL",
                 result=None,
                 reports=[],
                 kill_reason="TaskKillReason.COMPLETION_TIMEOUT",
@@ -271,7 +271,7 @@ class ParseApiResponse(TestCase):
                     to_dict(
                         fixture.task_result_dto(
                             finish_type=TaskFinishType.KILL,
-                            kill_reason=TaskKillReason.USER,
+                            kill_reason=USER,
                         )
                     )
                 ).encode(),
@@ -282,7 +282,7 @@ class ParseApiResponse(TestCase):
             dict(
                 command=fixture_api_result_command_dict,
                 task_ident="identifier",
-                task_finish_type="TaskFinishType.KILL",
+                task_finish_type="KILL",
                 result=None,
                 reports=[],
                 kill_reason="TaskKillReason.USER",
@@ -307,7 +307,7 @@ class ParseApiResponse(TestCase):
             dict(
                 task_ident="identifier",
                 command=fixture_api_result_command_dict,
-                task_finish_type="TaskFinishType.UNHANDLED_EXCEPTION",
+                task_finish_type="UNHANDLED_EXCEPTION",
                 result=None,
                 reports=[],
                 kill_reason=None,
@@ -358,7 +358,7 @@ class ParseApiResponse(TestCase):
             dict(
                 task_ident="identifier",
                 command=fixture_api_result_command_dict,
-                task_finish_type="TaskFinishType.SUCCESS",
+                task_finish_type="SUCCESS",
                 result=None,
                 reports=[
                     {

--- a/tests/unit/test_pcs_qdevice_certs.py
+++ b/tests/unit/test_pcs_qdevice_certs.py
@@ -84,7 +84,7 @@ class Pcs(TestCase):
                     "params": self.cmd_params,
                     "options": to_dict(self.cmd_options),
                 },
-                task_finish_type="TaskFinishType.SUCCESS",
+                task_finish_type="SUCCESS",
                 result=None,
                 reports=[],
                 kill_reason=None,
@@ -119,7 +119,7 @@ class Pcs(TestCase):
                     "params": self.cmd_params,
                     "options": to_dict(self.cmd_options),
                 },
-                task_finish_type="TaskFinishType.SUCCESS",
+                task_finish_type="SUCCESS",
                 result=certs_already_configured,
                 reports=[],
                 kill_reason=None,
@@ -143,7 +143,7 @@ class Pcs(TestCase):
             fixture.response_from_dto(
                 fixture.task_result_dto(
                     result=None,
-                    finish_type=TaskFinishType.UNHANDLED_EXCEPTION,
+                    finish_type=UNHANDLED_EXCEPTION,
                     command=self.cmd_check_dto,
                 )
             ),
@@ -188,7 +188,7 @@ class Pcs(TestCase):
                 fixture.response_from_dto(
                     fixture.task_result_dto(
                         result=None,
-                        finish_type=TaskFinishType.UNHANDLED_EXCEPTION,
+                        finish_type=UNHANDLED_EXCEPTION,
                         command=self.cmd_setup_dto,
                     )
                 ),


### PR DESCRIPTION
python unit tests are now giving errors like this:

```
E           Expected: exit_json(changed=True, pcs_result={'task_ident': 'identifier', 'command': {'command_name': 'quorum.device_net_certificate_setup_local', 'params': {'qnetd_host': 'node-q', 'cluster_name': 'test-cluster'}, 'options': {'request_timeout': None, 'effective_username': 'user', 'effective_groups': None}}, 'task_finish_type': 'TaskFinishType.SUCCESS', 'result': None, 'reports': [], 'kill_reason': None})
E             Actual: exit_json(changed=True, pcs_result={'task_ident': 'identifier', 'command': {'command_name': 'quorum.device_net_certificate_setup_local', 'params': {'qnetd_host': 'node-q', 'cluster_name': 'test-cluster'}, 'options': {'request_timeout': None, 'effective_username': 'user', 'effective_groups': None}}, 'task_finish_type': 'SUCCESS', 'result': None, 'reports': [], 'kill_reason': None})
```

It seems that the `TaskFinishType` is being omitted - not sure what happened.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Update unit tests to align expected task finish and kill reason values with the current enum string representations.

Bug Fixes:
- Fix failing Python unit tests by matching expected task_finish_type and kill_reason values to the enum values returned by the code.

Tests:
- Adjust pcs API v2 and qdevice certificate unit tests to expect bare enum value strings (e.g. "SUCCESS", "FAIL") instead of fully-qualified enum member names.