### PR TITLE
fix: crmsh - Replace crm_verify with crm configure verify

### DIFF
--- a/tasks/shell_crmsh/create-and-push-cib.yml
+++ b/tasks/shell_crmsh/create-and-push-cib.yml
@@ -251,27 +251,32 @@
         - ha_cluster_cluster_properties[0].attrs | length > 0
 
     # Verify CIB to ensure that there are no errors before applying.
+    # Original 'crm_verify' does not handle deprecated attributes correctly
+    # and fails with unhandled return code 78. Original command is:
+    # crm_verify -V \
+    #   -x /var/lib/pacemaker/cib/shadow.{{ __ha_cluster_crm_shadow }}
     - name: Verify shadow CIB
       ansible.builtin.command:
-        cmd: >-
-          crm_verify -V -x
-          /var/lib/pacemaker/cib/shadow.{{ __ha_cluster_crm_shadow }}
+        cmd: "crm --cib {{ __ha_cluster_crm_shadow }} configure verify"
       register: __ha_cluster_crm_verify
       ignore_errors: true
       check_mode: false
       changed_when: false
 
     ## Fail execution if shadow CIB is not valid.
-    ## Example: No STONITH resources were defined while stonith-enabled is true
+    # Example: No STONITH resources were defined while stonith-enabled is true
     - name: Fail if shadow CIB is invalid
       ansible.builtin.fail:
         msg: |
           FAIL: Cluster configuration was invalid.
           Following errors have to be remediated before retrying.
+          Command: crm --cib {{ __ha_cluster_crm_shadow }} configure verify
           Stdout: {{ __ha_cluster_crm_verify.stdout | d('') }}
           Stderr: {{ __ha_cluster_crm_verify.stderr | d('') }}
       when:
         - __ha_cluster_crm_verify.rc != 0
+        # Warnings are ignored,
+        # because they do not prevent CIB from being applied.
         - '"error" in __ha_cluster_crm_verify.stderr | d("") | lower'
       check_mode: false
 

--- a/tasks/shell_crmsh/create-and-push-cib.yml
+++ b/tasks/shell_crmsh/create-and-push-cib.yml
@@ -257,7 +257,7 @@
     #   -x /var/lib/pacemaker/cib/shadow.{{ __ha_cluster_crm_shadow }}
     - name: Verify shadow CIB
       ansible.builtin.command:
-        cmd: "crm --cib {{ __ha_cluster_crm_shadow }} configure verify"
+        cmd: crm --cib {{ __ha_cluster_crm_shadow }} configure verify
       register: __ha_cluster_crm_verify
       ignore_errors: true
       check_mode: false
@@ -273,11 +273,7 @@
           Command: crm --cib {{ __ha_cluster_crm_shadow }} configure verify
           Stdout: {{ __ha_cluster_crm_verify.stdout | d('') }}
           Stderr: {{ __ha_cluster_crm_verify.stderr | d('') }}
-      when:
-        - __ha_cluster_crm_verify.rc != 0
-        # Warnings are ignored,
-        # because they do not prevent CIB from being applied.
-        - '"error" in __ha_cluster_crm_verify.stderr | d("") | lower'
+      when: __ha_cluster_crm_verify.rc != 0
       check_mode: false
 
 


### PR DESCRIPTION
Enhancement:
- Replace Shadow CIB validation `crm_verify` command with command `crm --cib configure verify`.

> NOTE: Previously added workaround in `fail` module with `'"error" in __ha_cluster_crm_verify.stderr | d("") | lower'` is still kept in place as additional validation does not harm anything.

Reason:
- `crm_verify` command is handling CIB warnings with non-zero return code. `crm --cib configure verify` is returning RC 0 for warnings, while still showing them in output.

Example on SLES_SAP 16.1 with latest `pacemaker` and `crmsh`, which show deprecated warnings for `stonith-` properties:
```bash
sles161a:~ # crm_verify -V -x /var/lib/pacemaker/cib/shadow.shd
warning: Support for legacy name 'stonith-enabled' for cluster option 'fencing-enabled' is deprecated and will be removed in a future release
Configuration may need attention
sles161a:~ # echo $?
78

sles161a:~ # crm --cib shd configure verify
warning: Support for legacy name 'stonith-enabled' for cluster option 'fencing-enabled' is deprecated and will be removed in a future release
(unpack_config)         warning: Blind faith: not fencing unseen nodes
Configuration may need attention
WARNING: "stonith-enabled" is deprecated, please consider using "fencing-enabled"
sles161a:~ # echo $?
0
```

Result:
Successfully tested on:
- SLES_SAP 15 SP7
- SLES_SAP 16.0
- SLES_SAP 16.1 RC1 and RC2

Issue Tracker Tickets (Jira or BZ if any):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shadow cluster configuration verification by switching to a dedicated “CIB configure verify” process.
  * Updated the invalid-shadow failure check to trigger on verification return status only.
  * Enhanced the failure message to include the verification command and captured output (stdout/stderr) for faster diagnosis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->