### PR TITLE
test: add ha_cluster_test_skip_kernel_modules to skip modules used by test machines

### DIFF
--- a/tasks/shell_pcs/sbd.yml
+++ b/tasks/shell_pcs/sbd.yml
@@ -27,11 +27,12 @@
               community.general.modprobe:
                 name: "{{ module }}"
                 state: absent
-              loop: "{{
-                __ha_cluster_local_node.sbd_watchdog_modules_blocklist | d([])
-                }}"
+              loop: "{{ __blocklist | difference(__test_skip_list) | list }}"
               loop_control:
                 loop_var: module
+              vars:
+                __blocklist: "{{ __ha_cluster_local_node.sbd_watchdog_modules_blocklist | d([]) }}"
+                __test_skip_list: "{{ (ha_cluster_test_skip_kernel_modules | d('')).split(' ') | list }}"
 
         - name: Configure and load watchdog kernel module
           block:

--- a/tests/template_sbd_all_options.yml
+++ b/tests/template_sbd_all_options.yml
@@ -87,6 +87,7 @@
       assert:
         that:
           - "'iTCO_wdt' not in __test_sbd_watchdog_sbd_lsmod.stdout"
+      when: not "iTCO_wdt" in ha_cluster_test_skip_kernel_modules | d("")
 
     - name: Check lsmod output for SBD watchdog module
       assert:


### PR DESCRIPTION
Some of our test systems use kernel modules that ha_cluster cannot unload.  Add
ha_cluster_test_skip_kernel_modules which is a string containing a space delimited
list of names of kernel modules to skip or ignore.  This will be passed in by the
test framework on those machines which require modules that cannot be unloaded.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SBD watchdog module handling by excluding configured kernel modules from unloading.
  * Updated validation to accommodate intentionally skipped watchdog modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->