### PR TITLE
test: use __ha_cluster_test_modules_blocklist for testing with alternate modules

### DIFF
--- a/tests/template_sbd_all_options.yml
+++ b/tests/template_sbd_all_options.yml
@@ -13,14 +13,19 @@
         value: reboot,flush
       - name: watchdog-timeout
         value: 10
+    __ha_cluster_test_blocklist: "{{ [__ha_cluster_test_modules_blocklist]
+      if __ha_cluster_test_modules_blocklist is string
+      else __ha_cluster_test_modules_blocklist }}"
   block:
     - name: Ensure modprobe files are not present
       file:
         state: absent
         path: "{{ item }}"
-      loop:
-        - /etc/modprobe.d/iTCO_wdt.conf
-        - /etc/modules-load.d/softdog.conf
+      loop: "{{
+          (__ha_cluster_test_blocklist |
+           map('regex_replace', '^(.*)$', '/etc/modprobe.d/\\1.conf') |
+           list) + ['/etc/modules-load.d/softdog.conf']
+        }}"
 
     - name: Run HA Cluster role
       include_tasks: tasks/run_role_with_clear_facts.yml
@@ -29,27 +34,19 @@
 
     - name: Slurp generated SBD watchdog blocklist file
       slurp:
-        src: /etc/modprobe.d/iTCO_wdt.conf
+        src: "/etc/modprobe.d/{{ item }}.conf"
       register: __test_sbd_watchdog_blocklist_file
-
-    - name: Decode SBD watchdog blocklist file
-      set_fact:
-        __test_sbd_watchdog_blocklist_file_lines: "{{
-            (__test_sbd_watchdog_blocklist_file.content |
-            b64decode).splitlines()
-          }}"
-
-    - name: Print SBD watchdog blocklist file lines
-      debug:
-        var: __test_sbd_watchdog_blocklist_file_lines
+      loop: "{{ __ha_cluster_test_blocklist }}"
 
     - name: Check SBD watchdog blocklist file
       assert:
         that:
-          - __blockstr in __test_sbd_watchdog_blocklist_file_lines
+          - __blockstr in
+            (item.content | b64decode).splitlines()
       vars:
         # wokeignore:rule=blacklist
-        __blockstr: blacklist iTCO_wdt
+        __blockstr: "blacklist {{ item.item }}"
+      loop: "{{ __test_sbd_watchdog_blocklist_file.results }}"
 
     - name: Slurp generated SBD watchdog modprobe file
       slurp:
@@ -83,15 +80,24 @@
       debug:
         var: __test_sbd_watchdog_sbd_lsmod
 
+    - name: Get loaded module names from lsmod
+      set_fact:
+        __test_sbd_lsmod_modules: "{{
+            __test_sbd_watchdog_sbd_lsmod.stdout_lines |
+            map('regex_replace', '^(\\S+).*', '\\1') |
+            list
+          }}"
+
     - name: Check lsmod output for absence of SBD watchdog module blocklist
       assert:
         that:
-          - "'iTCO_wdt' not in __test_sbd_watchdog_sbd_lsmod.stdout"
+          - item not in __test_sbd_lsmod_modules
+      loop: "{{ __ha_cluster_test_blocklist }}"
 
     - name: Check lsmod output for SBD watchdog module
       assert:
         that:
-          - "'softdog' in __test_sbd_watchdog_sbd_lsmod.stdout"
+          - "'softdog' in __test_sbd_lsmod_modules"
 
     - name: Slurp SBD config file
       slurp:

--- a/tests/tests_sbd_all_options_combined.yml
+++ b/tests/tests_sbd_all_options_combined.yml
@@ -50,18 +50,22 @@
               {{
                 (__test_node_options | d([])) + [{
                   'node_name': hostvars[item]['inventory_hostname'],
-                  'sbd_watchdog_modules_blocklist': ['iTCO_wdt'],
+                  'sbd_watchdog_modules_blocklist': __ha_cluster_test_blocklist,
                   'sbd_watchdog': '/dev/null',
                   'sbd_devices': [__test_sbd_mount.stdout],
                 }]
               }}
           loop: "{{ ansible_play_hosts_all }}"
+          vars:
+            __ha_cluster_test_blocklist: "{{ [__ha_cluster_test_modules_blocklist]
+              if __ha_cluster_test_modules_blocklist is string
+              else __ha_cluster_test_modules_blocklist }}"
 
         # Expected values are:
         # sbd_watchdog_modules:
         #   - softdog  # defined in inventory only
-        # sbd_watchdog_modules_blocklist:
-        #   - iTCO_wdt  # defined in play only
+        # defined in play only
+        # sbd_watchdog_modules_blocklist: "{{ __ha_cluster_test_blocklist }}"
         # sbd_watchdog: /dev/null  # play overrides inventory
         # sbd_devices:
         #   - "{{ __test_sbd_mount.stdout }}"  # defined in both

--- a/tests/tests_sbd_all_options_inventory.yml
+++ b/tests/tests_sbd_all_options_inventory.yml
@@ -31,11 +31,14 @@
             ha_cluster:
               sbd_watchdog_modules:
                 - softdog
-              sbd_watchdog_modules_blocklist:
-                - iTCO_wdt
+              sbd_watchdog_modules_blocklist: "{{ __ha_cluster_test_blocklist }}"
               sbd_watchdog: /dev/null
               sbd_devices:
                 - "{{ __test_sbd_mount.stdout }}"
+          vars:
+            __ha_cluster_test_blocklist: "{{ [__ha_cluster_test_modules_blocklist]
+              if __ha_cluster_test_modules_blocklist is string
+              else __ha_cluster_test_modules_blocklist }}"
 
         - name: Run the role and assert results
           include_tasks: template_sbd_all_options.yml

--- a/tests/tests_sbd_all_options_play.yml
+++ b/tests/tests_sbd_all_options_play.yml
@@ -35,12 +35,16 @@
                 (__test_node_options | d([])) + [{
                   'node_name': hostvars[item]['inventory_hostname'],
                   'sbd_watchdog_modules': ['softdog'],
-                  'sbd_watchdog_modules_blocklist': ['iTCO_wdt'],
+                  'sbd_watchdog_modules_blocklist': __ha_cluster_test_blocklist,
                   'sbd_watchdog': '/dev/null',
                   'sbd_devices': [__test_sbd_mount.stdout],
                 }]
               }}
           loop: "{{ ansible_play_hosts_all }}"
+          vars:
+            __ha_cluster_test_blocklist: "{{ [__ha_cluster_test_modules_blocklist]
+              if __ha_cluster_test_modules_blocklist is string
+              else __ha_cluster_test_modules_blocklist }}"
 
         - name: Run the role and assert results
           include_tasks: template_sbd_all_options.yml

--- a/tests/vars/main.yml
+++ b/tests/vars/main.yml
@@ -1,2 +1,5 @@
 ---
 __test_fence_virt_supported: "{{ ansible_facts['architecture'] == 'x86_64' }}"
+# this can be a list or a string - it is easier for tests to pass in a single string
+# than a list - the test code will convert it to a list if needed
+__ha_cluster_test_modules_blocklist: ["iTCO_wdt"]


### PR DESCRIPTION
Some test machines use iTCO_wdt so we cannot use this module for testing the blocklist.
Instead, allow tests to pass in one or more modules for use for testing.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded SBD watchdog coverage to handle blocklists provided as either a single value or a list.
  * Added checks for every configured blocked module and improved verification of module absence.
  * Kept the existing `softdog` presence validation while making the test data more flexible and consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->