### PR TITLE
style: ignore linter issues in test_sr_fingerprint.py [citest_skip]

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -12,3 +12,6 @@ ignore_missing_imports = True
 
 [mypy-sr_fingerprint]
 ignore_errors = True
+
+[mypy-unit.test_sr_fingerprint]
+ignore_errors = True

--- a/pylintrc
+++ b/pylintrc
@@ -1,5 +1,5 @@
 [MAIN]
-ignore-paths=library/sr_fingerprint.py
+ignore-paths=library/sr_fingerprint.py, tests/unit/test_sr_fingerprint.py
 
 [MESSAGES CONTROL]
 disable=fixme, import-error, missing-module-docstring, use-dict-literal, wrong-import-position

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,12 @@ py-modules = []
 
 [tool.black]
 line-length = 80
-extend-exclude = "library/sr_fingerprint.py"
+extend-exclude = """(
+  ^/library/sr_fingerprint.py$
+  | ^/tests/unit/test_sr_fingerprint.py$
+)"""
 
 [tool.isort]
 profile = "black"
 line_length = 80
-extend_skip = ["library/sr_fingerprint.py"]
+extend_skip = ["library/sr_fingerprint.py", "tests/unit/test_sr_fingerprint.py"]


### PR DESCRIPTION
disable all linters for tests/unit/test_sr_fingerprint.py so that it can be maintained by automated means for all linux system roles