### PR TITLE
refactor: Relax ansible.posix and community.general version constraints

### DIFF
--- a/meta/collection-requirements.yml
+++ b/meta/collection-requirements.yml
@@ -2,7 +2,5 @@
 ---
 collections:
   - name: ansible.posix
-    version: '>=2.1.0,<2.2.0'
   - name: community.general
-    version: '>=6.6.0,<12.0.0'
   - name: fedora.linux_system_roles


### PR DESCRIPTION
## Enhancement

Remove the version caps and lower bounds on the `ansible.posix` and
`community.general` collection-requirements entries, leaving bare collection
names so the latest versions are used.

## Reason

The caps (`ansible.posix <2.2.0`, `community.general <12.0.0`) existed to
preserve EL7 compatibility, but ha_cluster does not support EL7 as a managed
node (`meta/main.yml` lists only EL 8 and 9). There is therefore no reason to
hold these collections back from their latest releases.

## Result

ha_cluster uses the latest `ansible.posix` and `community.general`.

## Issue Tracker Tickets (Jira or BZ if any)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated collection requirements to allow compatible versions of `ansible.posix` and `community.general` without fixed version constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->