### PR TITLE
ci: update status when action triggered by issue comment

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -24,6 +24,8 @@ env:
 permissions:
   contents: read
   pull-requests: read
+  # This is required for the ability to create/update the Pull request status
+  statuses: write
 jobs:
   ansible_lint:
     if: |
@@ -71,29 +73,41 @@ jobs:
           - { ansible_lint: "24.*", ansible: "2.16.*", python: "3.12" }
           - { ansible_lint: "26.*", ansible: "2.20.*", python: "3.13" }
     steps:
+      - name: Get PR head SHA and context
+        if: github.event_name == 'issue_comment'
+        id: head_sha_context
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          CONTEXT: "${{ github.workflow }} / ${{ github.job }} (${{ matrix.versions.ansible_lint }}, ${{ matrix.versions.ansible }}, ${{ matrix.versions.python }}) (pull_request)"
+        run: |
+          set -euxo pipefail
+          head_sha=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')
+          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+          echo "context=$CONTEXT" >> "$GITHUB_OUTPUT"
+
+      - name: Set commit status as pending
+        if: github.event_name == 'issue_comment'
+        uses: myrotvorets/set-commit-status-action@c0f880c99d91381c6fdb97726f03feb8004409b4  # master
+        with:
+          sha: ${{ steps.head_sha_context.outputs.head_sha }}
+          status: pending
+          context: ${{ steps.head_sha_context.outputs.context }}
+          description: Test started
+          targetUrl: ""
+
       - name: Update pip, git
         run: |
           set -euxo pipefail
           sudo apt update
           sudo apt install -y git
 
-      - name: Get PR head SHA
-        if: github.event_name == 'issue_comment'
-        id: head_sha
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.issue.number }}
-        run: |
-          set -euxo pipefail
-          head_sha=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')
-          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
-
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
-          ref: ${{ steps.head_sha.outputs.head_sha || github.sha }}
+          ref: ${{ steps.head_sha_context.outputs.head_sha || github.sha }}
 
       - name: Install tox, tox-lsr
         run: |
@@ -115,3 +129,13 @@ jobs:
           LSR_ANSIBLE_LINT_ANSIBLE_DEP="ansible-core==${{ matrix.versions.ansible }}" \
           tox -x testenv:ansible-lint-collection.basepython="python${{ matrix.versions.python }}" \
           -e ansible-lint-collection
+
+      - name: Set final commit status
+        if: always() && github.event_name == 'issue_comment' && steps.head_sha_context.outputs.head_sha != ''
+        uses: myrotvorets/set-commit-status-action@c0f880c99d91381c6fdb97726f03feb8004409b4  # master
+        with:
+          sha: ${{ steps.head_sha_context.outputs.head_sha }}
+          status: ${{ job.status }}
+          context: ${{ steps.head_sha_context.outputs.context }}
+          description: Test finished
+          targetUrl: ""

--- a/.github/workflows/ansible-managed-var-comment.yml
+++ b/.github/workflows/ansible-managed-var-comment.yml
@@ -21,6 +21,8 @@ on:  # yamllint disable-line rule:truthy
 permissions:
   contents: read
   pull-requests: read
+  # This is required for the ability to create/update the Pull request status
+  statuses: write
 jobs:
   ansible_managed_var_comment:
     if: |
@@ -59,6 +61,30 @@ jobs:
       )
     runs-on: ubuntu-latest
     steps:
+      - name: Get PR head SHA and context
+        if: github.event_name == 'issue_comment'
+        id: head_sha_context
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          CONTEXT: "${{ github.workflow }} / ${{ github.job }} (pull_request)"
+        run: |
+          set -euxo pipefail
+          head_sha=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')
+          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+          echo "context=$CONTEXT" >> "$GITHUB_OUTPUT"
+
+      - name: Set commit status as pending
+        if: github.event_name == 'issue_comment'
+        uses: myrotvorets/set-commit-status-action@c0f880c99d91381c6fdb97726f03feb8004409b4  # master
+        with:
+          sha: ${{ steps.head_sha_context.outputs.head_sha }}
+          status: pending
+          context: ${{ steps.head_sha_context.outputs.context }}
+          description: Test started
+          targetUrl: ""
+
       - name: Update pip, git
         run: |
           set -euxo pipefail
@@ -66,23 +92,11 @@ jobs:
           sudo apt update
           sudo apt install -y git
 
-      - name: Get PR head SHA
-        if: github.event_name == 'issue_comment'
-        id: head_sha
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.issue.number }}
-        run: |
-          set -euxo pipefail
-          head_sha=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')
-          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
-
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
-          ref: ${{ steps.head_sha.outputs.head_sha || github.sha }}
+          ref: ${{ steps.head_sha_context.outputs.head_sha || github.sha }}
 
       - name: Install tox, tox-lsr
         run: |
@@ -93,3 +107,13 @@ jobs:
         run: |
           set -euxo pipefail
           TOXENV=ansible-managed-var-comment lsr_ci_runtox
+
+      - name: Set final commit status
+        if: always() && github.event_name == 'issue_comment' && steps.head_sha_context.outputs.head_sha != ''
+        uses: myrotvorets/set-commit-status-action@c0f880c99d91381c6fdb97726f03feb8004409b4  # master
+        with:
+          sha: ${{ steps.head_sha_context.outputs.head_sha }}
+          status: ${{ job.status }}
+          context: ${{ steps.head_sha_context.outputs.context }}
+          description: Test finished
+          targetUrl: ""

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -24,6 +24,8 @@ env:
 permissions:
   contents: read
   pull-requests: read
+  # This is required for the ability to create/update the Pull request status
+  statuses: write
 jobs:
   ansible_test:
     if: |
@@ -73,6 +75,30 @@ jobs:
           - { ansible: "2-20", python: "3.13" }
           - { ansible: "milestone", python: "3.13" }
     steps:
+      - name: Get PR head SHA and context
+        if: github.event_name == 'issue_comment'
+        id: head_sha_context
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          CONTEXT: "${{ github.workflow }} / ${{ github.job }} (${{ matrix.versions.ansible }}, ${{ matrix.versions.python }}) (pull_request)"
+        run: |
+          set -euxo pipefail
+          head_sha=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')
+          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+          echo "context=$CONTEXT" >> "$GITHUB_OUTPUT"
+
+      - name: Set commit status as pending
+        if: github.event_name == 'issue_comment'
+        uses: myrotvorets/set-commit-status-action@c0f880c99d91381c6fdb97726f03feb8004409b4  # master
+        with:
+          sha: ${{ steps.head_sha_context.outputs.head_sha }}
+          status: pending
+          context: ${{ steps.head_sha_context.outputs.context }}
+          description: Test started
+          targetUrl: ""
+
       - name: Update pip, git
         run: |
           set -euxo pipefail
@@ -80,23 +106,11 @@ jobs:
           sudo apt update
           sudo apt install -y git
 
-      - name: Get PR head SHA
-        if: github.event_name == 'issue_comment'
-        id: head_sha
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.issue.number }}
-        run: |
-          set -euxo pipefail
-          head_sha=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')
-          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
-
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
-          ref: ${{ steps.head_sha.outputs.head_sha || github.sha }}
+          ref: ${{ steps.head_sha_context.outputs.head_sha || github.sha }}
 
       - name: Install tox, tox-lsr
         run: |
@@ -116,3 +130,13 @@ jobs:
           tox \
             -x testenv:ansible-test-${{ matrix.versions.ansible }}.basepython="python${{ matrix.versions.python }}" \
             -e ansible-test-${{ matrix.versions.ansible }}
+
+      - name: Set final commit status
+        if: always() && github.event_name == 'issue_comment' && steps.head_sha_context.outputs.head_sha != ''
+        uses: myrotvorets/set-commit-status-action@c0f880c99d91381c6fdb97726f03feb8004409b4  # master
+        with:
+          sha: ${{ steps.head_sha_context.outputs.head_sha }}
+          status: ${{ job.status }}
+          context: ${{ steps.head_sha_context.outputs.context }}
+          description: Test finished
+          targetUrl: ""

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,6 +22,8 @@ on:  # yamllint disable-line rule:truthy
 permissions:
   contents: read
   pull-requests: read
+  # This is required for the ability to create/update the Pull request status
+  statuses: write
 jobs:
   analyze:
     if: |
@@ -65,33 +67,47 @@ jobs:
       actions: read
       contents: read
       security-events: write
+      statuses: write
     strategy:
       fail-fast: false
       matrix:
         language: [python]
     steps:
+      - name: Get PR head SHA and context
+        if: github.event_name == 'issue_comment'
+        id: head_sha_context
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          CONTEXT: "${{ github.workflow }} / Analyze (${{ matrix.language }}) (pull_request)"
+        run: |
+          set -euxo pipefail
+          head_sha=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')
+          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+          echo "context=$CONTEXT" >> "$GITHUB_OUTPUT"
+
+      - name: Set commit status as pending
+        if: github.event_name == 'issue_comment'
+        uses: myrotvorets/set-commit-status-action@c0f880c99d91381c6fdb97726f03feb8004409b4  # master
+        with:
+          sha: ${{ steps.head_sha_context.outputs.head_sha }}
+          status: pending
+          context: ${{ steps.head_sha_context.outputs.context }}
+          description: Test started
+          targetUrl: ""
+
       - name: Update pip, git
         run: |
           set -euxo pipefail
           sudo apt update
           sudo apt install -y git
-      - name: Get PR head SHA
-        if: github.event_name == 'issue_comment'
-        id: head_sha
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.issue.number }}
-        run: |
-          set -euxo pipefail
-          head_sha=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')
-          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
-          ref: ${{ steps.head_sha.outputs.head_sha || github.sha }}
+          ref: ${{ steps.head_sha_context.outputs.head_sha || github.sha }}
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938  # v4.37.9
@@ -106,3 +122,13 @@ jobs:
         uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938  # v4.37.9
         with:
           category: "/language:${{ matrix.language }}"
+
+      - name: Set final commit status
+        if: always() && github.event_name == 'issue_comment' && steps.head_sha_context.outputs.head_sha != ''
+        uses: myrotvorets/set-commit-status-action@c0f880c99d91381c6fdb97726f03feb8004409b4  # master
+        with:
+          sha: ${{ steps.head_sha_context.outputs.head_sha }}
+          status: ${{ job.status }}
+          context: ${{ steps.head_sha_context.outputs.context }}
+          description: Test finished
+          targetUrl: ""

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -13,6 +13,8 @@ on:  # yamllint disable-line rule:truthy
 permissions:
   contents: read
   pull-requests: read
+  # This is required for the ability to create/update the Pull request status
+  statuses: write
 jobs:
   codespell:
     if: |
@@ -52,23 +54,45 @@ jobs:
     name: Check for spelling errors
     runs-on: ubuntu-latest
     steps:
-      - name: Get PR head SHA
+      - name: Get PR head SHA and context
         if: github.event_name == 'issue_comment'
-        id: head_sha
+        id: head_sha_context
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.issue.number }}
+          CONTEXT: "${{ github.workflow }} / Check for spelling errors (pull_request)"
         run: |
           set -euxo pipefail
           head_sha=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')
           echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+          echo "context=$CONTEXT" >> "$GITHUB_OUTPUT"
+
+      - name: Set commit status as pending
+        if: github.event_name == 'issue_comment'
+        uses: myrotvorets/set-commit-status-action@c0f880c99d91381c6fdb97726f03feb8004409b4  # master
+        with:
+          sha: ${{ steps.head_sha_context.outputs.head_sha }}
+          status: pending
+          context: ${{ steps.head_sha_context.outputs.context }}
+          description: Test started
+          targetUrl: ""
 
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
-          ref: ${{ steps.head_sha.outputs.head_sha || github.sha }}
+          ref: ${{ steps.head_sha_context.outputs.head_sha || github.sha }}
 
       - name: Codespell
         uses: codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579  # v2.2
+
+      - name: Set final commit status
+        if: always() && github.event_name == 'issue_comment' && steps.head_sha_context.outputs.head_sha != ''
+        uses: myrotvorets/set-commit-status-action@c0f880c99d91381c6fdb97726f03feb8004409b4  # master
+        with:
+          sha: ${{ steps.head_sha_context.outputs.head_sha }}
+          status: ${{ job.status }}
+          context: ${{ steps.head_sha_context.outputs.context }}
+          description: Test finished
+          targetUrl: ""

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -22,6 +22,8 @@ on:  # yamllint disable-line rule:truthy
 permissions:
   contents: read
   pull-requests: read
+  # This is required for the ability to create/update the Pull request status
+  statuses: write
 jobs:
   markdownlint:
     if: |
@@ -60,29 +62,41 @@ jobs:
       )
     runs-on: ubuntu-latest
     steps:
+      - name: Get PR head SHA and context
+        if: github.event_name == 'issue_comment'
+        id: head_sha_context
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          CONTEXT: "${{ github.workflow }} / ${{ github.job }} (pull_request)"
+        run: |
+          set -euxo pipefail
+          head_sha=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')
+          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+          echo "context=$CONTEXT" >> "$GITHUB_OUTPUT"
+
+      - name: Set commit status as pending
+        if: github.event_name == 'issue_comment'
+        uses: myrotvorets/set-commit-status-action@c0f880c99d91381c6fdb97726f03feb8004409b4  # master
+        with:
+          sha: ${{ steps.head_sha_context.outputs.head_sha }}
+          status: pending
+          context: ${{ steps.head_sha_context.outputs.context }}
+          description: Test started
+          targetUrl: ""
+
       - name: Update pip, git
         run: |
           set -euxo pipefail
           sudo apt update
           sudo apt install -y git
 
-      - name: Get PR head SHA
-        if: github.event_name == 'issue_comment'
-        id: head_sha
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.issue.number }}
-        run: |
-          set -euxo pipefail
-          head_sha=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')
-          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
-
       - name: Check out code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
-          ref: ${{ steps.head_sha.outputs.head_sha || github.sha }}
+          ref: ${{ steps.head_sha_context.outputs.head_sha || github.sha }}
 
       # CHANGELOG.md is generated automatically from PR titles and descriptions
       # It might have issues but they are not critical
@@ -93,3 +107,13 @@ jobs:
             --ignore=CHANGELOG.md
             **/*.md
           config: .markdownlint.yaml
+
+      - name: Set final commit status
+        if: always() && github.event_name == 'issue_comment' && steps.head_sha_context.outputs.head_sha != ''
+        uses: myrotvorets/set-commit-status-action@c0f880c99d91381c6fdb97726f03feb8004409b4  # master
+        with:
+          sha: ${{ steps.head_sha_context.outputs.head_sha }}
+          status: ${{ job.status }}
+          context: ${{ steps.head_sha_context.outputs.context }}
+          description: Test finished
+          targetUrl: ""

--- a/.github/workflows/python-unit-test.yml
+++ b/.github/workflows/python-unit-test.yml
@@ -22,6 +22,8 @@ on:  # yamllint disable-line rule:truthy
 permissions:
   contents: read
   pull-requests: read
+  # This is required for the ability to create/update the Pull request status
+  statuses: write
 jobs:
   python:
     if: |
@@ -130,29 +132,41 @@ jobs:
             pcs_site_packages: dist-packages
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Get PR head SHA and context
+        if: github.event_name == 'issue_comment'
+        id: head_sha_context
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          CONTEXT: "${{ github.workflow }} / ${{ github.job }} (${{ matrix.os }}, ${{ matrix.pcs_version }}${{ matrix.pcs_dir_local && format(', {0}', matrix.pcs_dir_local) || '' }}, ${{ matrix.pcs_site_packages }}) (pull_request)"
+        run: |
+          set -euxo pipefail
+          head_sha=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')
+          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+          echo "context=$CONTEXT" >> "$GITHUB_OUTPUT"
+
+      - name: Set commit status as pending
+        if: github.event_name == 'issue_comment'
+        uses: myrotvorets/set-commit-status-action@c0f880c99d91381c6fdb97726f03feb8004409b4  # master
+        with:
+          sha: ${{ steps.head_sha_context.outputs.head_sha }}
+          status: pending
+          context: ${{ steps.head_sha_context.outputs.context }}
+          description: Test started
+          targetUrl: ""
+
       - name: Update git
         run: |
           set -euxo pipefail
           sudo apt update
           sudo apt install -y git
 
-      - name: Get PR head SHA
-        if: github.event_name == 'issue_comment'
-        id: head_sha
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.issue.number }}
-        run: |
-          set -euxo pipefail
-          head_sha=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')
-          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
-
       - name: checkout PR
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
-          ref: ${{ steps.head_sha.outputs.head_sha || github.sha }}
+          ref: ${{ steps.head_sha_context.outputs.head_sha || github.sha }}
 
       - name: Install platform dependencies, python, tox, tox-lsr
         run: |
@@ -211,3 +225,13 @@ jobs:
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7
+
+      - name: Set final commit status
+        if: always() && github.event_name == 'issue_comment' && steps.head_sha_context.outputs.head_sha != ''
+        uses: myrotvorets/set-commit-status-action@c0f880c99d91381c6fdb97726f03feb8004409b4  # master
+        with:
+          sha: ${{ steps.head_sha_context.outputs.head_sha }}
+          status: ${{ job.status }}
+          context: ${{ steps.head_sha_context.outputs.context }}
+          description: Test finished
+          targetUrl: ""

--- a/.github/workflows/qemu-kvm-integration-tests.yml
+++ b/.github/workflows/qemu-kvm-integration-tests.yml
@@ -90,23 +90,35 @@ jobs:
       ANSIBLE_INJECT_FACT_VARS: "false"
 
     steps:
-      - name: Get PR head SHA
+      - name: Get PR head SHA and context
         if: github.event_name == 'issue_comment'
-        id: head_sha
+        id: head_sha_context
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.issue.number }}
+          CONTEXT: "${{ github.workflow }} / scenario (${{ matrix.scenario.image }}, ${{ matrix.scenario.env }}) (pull_request)"
         run: |
           set -euxo pipefail
           head_sha=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')
           echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+          echo "context=$CONTEXT" >> "$GITHUB_OUTPUT"
+
+      - name: Set commit status as pending
+        if: github.event_name == 'issue_comment'
+        uses: myrotvorets/set-commit-status-action@c0f880c99d91381c6fdb97726f03feb8004409b4  # master
+        with:
+          sha: ${{ steps.head_sha_context.outputs.head_sha }}
+          status: pending
+          context: ${{ steps.head_sha_context.outputs.context }}
+          description: Test started
+          targetUrl: ""
 
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
-          ref: ${{ steps.head_sha.outputs.head_sha || github.sha }}
+          ref: ${{ steps.head_sha_context.outputs.head_sha || github.sha }}
 
       - name: Check if platform is supported
         id: check_platform
@@ -290,11 +302,22 @@ jobs:
           done
           "${cmdline[@]}"
 
-      - name: Set commit status as success with a description that platform is skipped
-        if: ${{ steps.check_platform.outputs.supported == '' }}
+      - name: Set final commit status
+        if: always() && github.event_name == 'issue_comment' && steps.head_sha_context.outputs.head_sha != '' && (steps.check_platform.outputs.supported || failure())
         uses: myrotvorets/set-commit-status-action@c0f880c99d91381c6fdb97726f03feb8004409b4  # master
         with:
+          sha: ${{ steps.head_sha_context.outputs.head_sha }}
+          status: ${{ job.status }}
+          context: ${{ steps.head_sha_context.outputs.context }}
+          description: Test finished
+          targetUrl: ""
+
+      - name: Set commit status as success with a description that platform is skipped
+        if: ${{ success() && github.event_name == 'issue_comment' && steps.check_platform.outputs.supported == '' }}
+        uses: myrotvorets/set-commit-status-action@c0f880c99d91381c6fdb97726f03feb8004409b4  # master
+        with:
+          sha: ${{ steps.head_sha_context.outputs.head_sha }}
           status: success
-          context: "${{ github.workflow }} / scenario (${{ matrix.scenario.image }}, ${{ matrix.scenario.env }}) (pull_request)"
+          context: ${{ steps.head_sha_context.outputs.context }}
           description: The role does not support this platform. Skipping.
           targetUrl: ""

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -24,6 +24,8 @@ env:
 permissions:
   contents: read
   pull-requests: read
+  # This is required for the ability to create/update the Pull request status
+  statuses: write
 jobs:
   shellcheck:
     if: |
@@ -62,29 +64,41 @@ jobs:
       )
     runs-on: ubuntu-latest
     steps:
+      - name: Get PR head SHA and context
+        if: github.event_name == 'issue_comment'
+        id: head_sha_context
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          CONTEXT: "${{ github.workflow }} / ${{ github.job }} (pull_request)"
+        run: |
+          set -euxo pipefail
+          head_sha=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')
+          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+          echo "context=$CONTEXT" >> "$GITHUB_OUTPUT"
+
+      - name: Set commit status as pending
+        if: github.event_name == 'issue_comment'
+        uses: myrotvorets/set-commit-status-action@c0f880c99d91381c6fdb97726f03feb8004409b4  # master
+        with:
+          sha: ${{ steps.head_sha_context.outputs.head_sha }}
+          status: pending
+          context: ${{ steps.head_sha_context.outputs.context }}
+          description: Test started
+          targetUrl: ""
+
       - name: Update git
         run: |
           set -euxo pipefail
           sudo apt update
           sudo apt install -y git
 
-      - name: Get PR head SHA
-        if: github.event_name == 'issue_comment'
-        id: head_sha
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.issue.number }}
-        run: |
-          set -euxo pipefail
-          head_sha=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')
-          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
-
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
-          ref: ${{ steps.head_sha.outputs.head_sha || github.sha }}
+          ref: ${{ steps.head_sha_context.outputs.head_sha || github.sha }}
 
       - name: Run ShellCheck
         id: shellcheck_id
@@ -94,3 +108,13 @@ jobs:
         run: |
           echo Files scanned:
           echo "${{ steps.shellcheck_id.outputs.files }}"
+
+      - name: Set final commit status
+        if: always() && github.event_name == 'issue_comment' && steps.head_sha_context.outputs.head_sha != ''
+        uses: myrotvorets/set-commit-status-action@c0f880c99d91381c6fdb97726f03feb8004409b4  # master
+        with:
+          sha: ${{ steps.head_sha_context.outputs.head_sha }}
+          status: ${{ job.status }}
+          context: ${{ steps.head_sha_context.outputs.context }}
+          description: Test finished
+          targetUrl: ""

--- a/.github/workflows/test_converting_readme.yml
+++ b/.github/workflows/test_converting_readme.yml
@@ -21,6 +21,8 @@ on:  # yamllint disable-line rule:truthy
 permissions:
   contents: read
   pull-requests: read
+  # This is required for the ability to create/update the Pull request status
+  statuses: write
 jobs:
   test_converting_readme:
     if: |
@@ -61,30 +63,43 @@ jobs:
     permissions:
       pull-requests: read
       contents: write
+      statuses: write
     steps:
+      - name: Get PR head SHA and context
+        if: github.event_name == 'issue_comment'
+        id: head_sha_context
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          CONTEXT: "${{ github.workflow }} / ${{ github.job }} (pull_request)"
+        run: |
+          set -euxo pipefail
+          head_sha=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')
+          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+          echo "context=$CONTEXT" >> "$GITHUB_OUTPUT"
+
+      - name: Set commit status as pending
+        if: github.event_name == 'issue_comment'
+        uses: myrotvorets/set-commit-status-action@c0f880c99d91381c6fdb97726f03feb8004409b4  # master
+        with:
+          sha: ${{ steps.head_sha_context.outputs.head_sha }}
+          status: pending
+          context: ${{ steps.head_sha_context.outputs.context }}
+          description: Test started
+          targetUrl: ""
+
       - name: Update pip, git
         run: |
           set -euxo pipefail
           sudo apt update
           sudo apt install -y git
 
-      - name: Get PR head SHA
-        if: github.event_name == 'issue_comment'
-        id: head_sha
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.issue.number }}
-        run: |
-          set -euxo pipefail
-          head_sha=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')
-          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
-
       - name: Check out code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
-          ref: ${{ steps.head_sha.outputs.head_sha || github.sha }}
+          ref: ${{ steps.head_sha_context.outputs.head_sha || github.sha }}
 
       - name: Remove badges from README.md prior to converting to HTML
         run: sed -i '1,8 {/^\[\!.*actions\/workflows/d}' README.md
@@ -102,3 +117,13 @@ jobs:
         with:
           name: README.html
           path: README.html
+
+      - name: Set final commit status
+        if: always() && github.event_name == 'issue_comment' && steps.head_sha_context.outputs.head_sha != ''
+        uses: myrotvorets/set-commit-status-action@c0f880c99d91381c6fdb97726f03feb8004409b4  # master
+        with:
+          sha: ${{ steps.head_sha_context.outputs.head_sha }}
+          status: ${{ job.status }}
+          context: ${{ steps.head_sha_context.outputs.context }}
+          description: Test finished
+          targetUrl: ""

--- a/.github/workflows/tft.yml
+++ b/.github/workflows/tft.yml
@@ -19,7 +19,7 @@ jobs:
     name: Get info from role and PR to determine if and how to test
     # The concurrency key is used to prevent multiple workflows from running at the same time
     concurrency:
-      # group name contains reponame-pr_num to allow simualteneous runs in different PRs
+      # group name contains reponame-pr_num to allow simultaneous runs in different PRs
       group: testing-farm-${{ github.event.repository.name }}-${{ github.event.issue.number || github.event.number }}
       cancel-in-progress: true
     # Let's schedule tests only on user request. NOT automatically.
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       supported_platforms: ${{ steps.supported_platforms.outputs.supported_platforms }}
-      head_sha: ${{ steps.head_sha.outputs.head_sha }}
+      head_sha: ${{ steps.head_sha.outputs.head_sha || github.sha }}
       memory: ${{ steps.memory.outputs.memory }}
     steps:
       - name: Dump github context
@@ -161,6 +161,28 @@ jobs:
         ${{ needs.prepare_vars.outputs.datetime }}/artifacts"
       ARTIFACT_TARGET_DIR: /srv/pub/alt/${{ vars.SR_LSR_USER }}/logs
     steps:
+      # the head_sha isn't really needed to be set here, we could
+      # just use the prepare_vars output, but this makes the workflow
+      # consistent with the other issue comment workflows.
+      - name: Get PR head SHA and context
+        id: head_sha_context
+        env:
+          HEAD_SHA: ${{ needs.prepare_vars.outputs.head_sha }}
+          CONTEXT: ${{ matrix.platform }}|ansible-${{ matrix.ansible_version }}
+        run: |
+          echo "head_sha=$HEAD_SHA" >> $GITHUB_OUTPUT
+          echo "context=$CONTEXT" >> $GITHUB_OUTPUT
+
+      - name: Set commit status as pending
+        if: contains(needs.prepare_vars.outputs.supported_platforms, matrix.platform)
+        uses: myrotvorets/set-commit-status-action@c0f880c99d91381c6fdb97726f03feb8004409b4  # master
+        with:
+          sha: ${{ steps.head_sha_context.outputs.head_sha }}
+          status: pending
+          context: ${{ steps.head_sha_context.outputs.context }}
+          description: Test started
+          targetUrl: ""
+
       - name: Set variables with DATETIME and artifact location
         id: set_vars
         run: |
@@ -174,23 +196,13 @@ jobs:
           echo "ARTIFACTS_DIR=$ARTIFACTS_DIR" >> $GITHUB_OUTPUT
           echo "ARTIFACTS_URL=$ARTIFACTS_URL" >> $GITHUB_OUTPUT
 
-      - name: Set commit status as pending
-        if: contains(needs.prepare_vars.outputs.supported_platforms, matrix.platform)
-        uses: myrotvorets/set-commit-status-action@c0f880c99d91381c6fdb97726f03feb8004409b4  # master
-        with:
-          sha: ${{ needs.prepare_vars.outputs.head_sha }}
-          status: pending
-          context: ${{ matrix.platform }}|ansible-${{ matrix.ansible_version }}
-          description: Test started
-          targetUrl: ""
-
       - name: Set commit status as success with a description that platform is skipped
         if: "!contains(needs.prepare_vars.outputs.supported_platforms, matrix.platform)"
         uses: myrotvorets/set-commit-status-action@c0f880c99d91381c6fdb97726f03feb8004409b4  # master
         with:
-          sha: ${{ needs.prepare_vars.outputs.head_sha }}
+          sha: ${{ steps.head_sha_context.outputs.head_sha }}
           status: success
-          context: ${{ matrix.platform }}|ansible-${{ matrix.ansible_version }}
+          context: ${{ steps.head_sha_context.outputs.context }}
           description: The role does not support this platform. Skipping.
           targetUrl: ""
 
@@ -227,8 +239,8 @@ jobs:
         uses: myrotvorets/set-commit-status-action@c0f880c99d91381c6fdb97726f03feb8004409b4  # master
         if: always() && contains(needs.prepare_vars.outputs.supported_platforms, matrix.platform)
         with:
-          sha: ${{ needs.prepare_vars.outputs.head_sha }}
+          sha: ${{ steps.head_sha_context.outputs.head_sha }}
           status: ${{ job.status }}
-          context: ${{ matrix.platform }}|ansible-${{ matrix.ansible_version }}
+          context: ${{ steps.head_sha_context.outputs.context }}
           description: Test finished
           targetUrl: ${{ steps.set_vars.outputs.ARTIFACTS_URL }}

--- a/.github/workflows/woke.yml
+++ b/.github/workflows/woke.yml
@@ -13,6 +13,8 @@ on:  # yamllint disable-line rule:truthy
 permissions:
   contents: read
   pull-requests: read
+  # This is required for the ability to create/update the Pull request status
+  statuses: write
 jobs:
   woke:
     if: |
@@ -52,23 +54,35 @@ jobs:
     name: Detect non-inclusive language
     runs-on: ubuntu-latest
     steps:
-      - name: Get PR head SHA
+      - name: Get PR head SHA and context
         if: github.event_name == 'issue_comment'
-        id: head_sha
+        id: head_sha_context
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.issue.number }}
+          CONTEXT: "${{ github.workflow }} / Detect non-inclusive language (pull_request)"
         run: |
           set -euxo pipefail
           head_sha=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')
           echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+          echo "context=$CONTEXT" >> "$GITHUB_OUTPUT"
+
+      - name: Set commit status as pending
+        if: github.event_name == 'issue_comment'
+        uses: myrotvorets/set-commit-status-action@c0f880c99d91381c6fdb97726f03feb8004409b4  # master
+        with:
+          sha: ${{ steps.head_sha_context.outputs.head_sha }}
+          status: pending
+          context: ${{ steps.head_sha_context.outputs.context }}
+          description: Test started
+          targetUrl: ""
 
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
-          ref: ${{ steps.head_sha.outputs.head_sha || github.sha }}
+          ref: ${{ steps.head_sha_context.outputs.head_sha || github.sha }}
 
       - name: Run lsr-woke-action
         # Originally, uses: get-woke/woke-action@v0
@@ -77,3 +91,13 @@ jobs:
           woke-args: "-c https://raw.githubusercontent.com/linux-system-roles/tox-lsr/main/src/tox_lsr/config_files/woke.yml --count-only-error-for-failure"
           # Cause the check to fail on any broke rules
           fail-on-error: true
+
+      - name: Set final commit status
+        if: always() && github.event_name == 'issue_comment' && steps.head_sha_context.outputs.head_sha != ''
+        uses: myrotvorets/set-commit-status-action@c0f880c99d91381c6fdb97726f03feb8004409b4  # master
+        with:
+          sha: ${{ steps.head_sha_context.outputs.head_sha }}
+          status: ${{ job.status }}
+          context: ${{ steps.head_sha_context.outputs.context }}
+          description: Test finished
+          targetUrl: ""


### PR DESCRIPTION
issue comment triggers do not automatically update check status in the PR, so
use separate steps to update them, similar to how the tft.yml workflow works.
For issue comment workflows, ensure that the head_sha is set early in the
workflow and the status is only updated if there is a head_sha.

Create a variable for context so it is created in one place and used in several
places in the workflow.

Ensure that the first steps in the workflow are to get the head_sha and set the
status to In Progress.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added commit status reporting for issue-comment-triggered checks.
  - Checks now show a pending status while running and a final status when complete, including failures.
  - Improved status details identify the specific workflow, job, platform, or test configuration.
  - Workflows consistently test the pull request’s latest commit and report results against it.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->